### PR TITLE
Make RPC events threaded

### DIFF
--- a/sleekxmpp/plugins/xep_0009/remote.py
+++ b/sleekxmpp/plugins/xep_0009/remote.py
@@ -699,10 +699,10 @@ class Remote(object):
             with Remote._lock:
                 del cls._sessions[client.boundjid.bare]
         result = RemoteSession(client, _session_close_callback)
-        client.plugin['xep_0009'].xmpp.add_event_handler('jabber_rpc_method_call', result._on_jabber_rpc_method_call)
-        client.plugin['xep_0009'].xmpp.add_event_handler('jabber_rpc_method_response', result._on_jabber_rpc_method_response)
-        client.plugin['xep_0009'].xmpp.add_event_handler('jabber_rpc_method_fault', result._on_jabber_rpc_method_fault)
-        client.plugin['xep_0009'].xmpp.add_event_handler('jabber_rpc_error', result._on_jabber_rpc_error)
+        client.plugin['xep_0009'].xmpp.add_event_handler('jabber_rpc_method_call', result._on_jabber_rpc_method_call, threaded=True)
+        client.plugin['xep_0009'].xmpp.add_event_handler('jabber_rpc_method_response', result._on_jabber_rpc_method_response, threaded=True)
+        client.plugin['xep_0009'].xmpp.add_event_handler('jabber_rpc_method_fault', result._on_jabber_rpc_method_fault, threaded=True)
+        client.plugin['xep_0009'].xmpp.add_event_handler('jabber_rpc_error', result._on_jabber_rpc_error, threaded=True)
         if callback is None:
             start_event_handler = result._notify
         else:


### PR DESCRIPTION
Threading the RPC events makes it possible to create an RPC command that queries another RPC service for data.

i.e.:

``` python
class BackendRPC(Endpoint):
    def FQN(self):
        return 'backend'
    @remote
    def originate(self, extension_id, extension):
        return NotImplemented
class MyRPC(Endpoint):
    def FQN(self):
        return 'test'
    @remote
    def originate(self, src, dst):
        backend = self.session.new_proxy('backend@localhost/dummy', BackendRPC)
        return backend.originate(src, dst)
```

Without the patch, `return backend.originate(src, dst)` would throw a timeout error, as it blocks with an [event.wait(30)](http://docs.python.org/library/threading.html#threading.Event.wait), thus preventing the value it's waiting for from being updated until it's given up.
