### PR TITLE
XEP-0009: ACL.check fix

### DIFF
--- a/sleekxmpp/plugins/xep_0009/remote.py
+++ b/sleekxmpp/plugins/xep_0009/remote.py
@@ -113,6 +113,9 @@ class ACL:
     def check(cls, rules, jid, resource):
         if rules is None:
             return cls.DENY                  # No rules means no access!
+        jid = str(jid)     # Check the string representation of the JID.
+        if not jid:
+            return cls.DENY                  # Can't check an empty JID.
         for rule in rules:
             policy = cls._check(rule, jid, resource)
             if policy is not None:


### PR DESCRIPTION
Fixes Issue 93. ACL.check is calling a string method on a JID object.
