### PR TITLE
XEP-0009 XML-RPC value conversion fixes and unit tests

### DIFF
--- a/sleekxmpp/plugins/xep_0009/binding.py
+++ b/sleekxmpp/plugins/xep_0009/binding.py
@@ -42,46 +42,46 @@ def py2xml(*args):
 
 def _py2xml(*args):
     for x in args:
-        val = ET.Element("value")
+        val = ET.Element("{%s}value" % _namespace)
         if x is None:
-            nil = ET.Element("nil")
+            nil = ET.Element("{%s}nil" % _namespace)
             val.append(nil)
         elif type(x) is int:
-            i4 = ET.Element("i4")
+            i4 = ET.Element("{%s}i4" % _namespace)
             i4.text = str(x)
             val.append(i4)
         elif type(x) is bool:
-            boolean = ET.Element("boolean")
+            boolean = ET.Element("{%s}boolean" % _namespace)
             boolean.text = str(int(x))
             val.append(boolean)
         elif type(x) is str:
-            string = ET.Element("string")
+            string = ET.Element("{%s}string" % _namespace)
             string.text = x
             val.append(string)
         elif type(x) is float:
-            double = ET.Element("double")
+            double = ET.Element("{%s}double" % _namespace)
             double.text = str(x)
             val.append(double)
         elif type(x) is rpcbase64:
-            b64 = ET.Element("base64")
+            b64 = ET.Element("{%s}base64" % _namespace)
             b64.text = x.encoded()
             val.append(b64)
         elif type(x) is rpctime:
-            iso = ET.Element("dateTime.iso8601")
+            iso = ET.Element("{%s}dateTime.iso8601" % _namespace)
             iso.text = str(x)
             val.append(iso)
         elif type(x) in (list, tuple):
-            array = ET.Element("array")
-            data = ET.Element("data")
+            array = ET.Element("{%s}array" % _namespace)
+            data = ET.Element("{%s}data" % _namespace)
             for y in x:
                 data.append(_py2xml(y))
             array.append(data)
             val.append(array)
         elif type(x) is dict:
-            struct = ET.Element("struct")
+            struct = ET.Element("{%s}struct" % _namespace)
             for y in x.keys():
-                member = ET.Element("member")
-                name = ET.Element("name")
+                member = ET.Element("{%s}member" % _namespace)
+                name = ET.Element("{%s}name" % _namespace)
                 name.text = y
                 member.append(name)
                 member.append(_py2xml(x[y]))
@@ -110,13 +110,13 @@ def _xml2py(value):
         return value.find('{%s}string' % namespace).text
     if value.find('{%s}double' % namespace) is not None:
         return float(value.find('{%s}double' % namespace).text)
-    if value.find('{%s}base64') is not None:
-        return rpcbase64(value.find('base64' % namespace).text)
-    if value.find('{%s}Base64') is not None:
+    if value.find('{%s}base64' % namespace) is not None:
+        return rpcbase64(value.find('{%s}base64' % namespace).text)
+    if value.find('{%s}Base64' % namespace) is not None:
         # Older versions of XEP-0009 used Base64
-        return rpcbase64(value.find('Base64' % namespace).text)
-    if value.find('{%s}dateTime.iso8601') is not None:
-        return rpctime(value.find('{%s}dateTime.iso8601'))
+        return rpcbase64(value.find('{%s}Base64' % namespace).text)
+    if value.find('{%s}dateTime.iso8601' % namespace) is not None:
+        return rpctime(value.find('{%s}dateTime.iso8601' % namespace).text)
     if value.find('{%s}struct' % namespace) is not None:
         struct = {}
         for member in value.find('{%s}struct' % namespace).findall('{%s}member' % namespace):

--- a/sleekxmpp/plugins/xep_0009/binding.py
+++ b/sleekxmpp/plugins/xep_0009/binding.py
@@ -105,7 +105,7 @@ def _xml2py(value):
     if value.find('{%s}int' % namespace) is not None:
         return int(value.find('{%s}int' % namespace).text)
     if value.find('{%s}boolean' % namespace) is not None:
-        return bool(value.find('{%s}boolean' % namespace).text)
+        return bool(int(value.find('{%s}boolean' % namespace).text))
     if value.find('{%s}string' % namespace) is not None:
         return value.find('{%s}string' % namespace).text
     if value.find('{%s}double' % namespace) is not None:

--- a/tests/test_stanza_xep_0009.py
+++ b/tests/test_stanza_xep_0009.py
@@ -6,23 +6,27 @@
     See the file LICENSE for copying permission.
 """
 
+import base64
+
 from sleekxmpp.plugins.xep_0009.stanza.RPC import RPCQuery, MethodCall, \
     MethodResponse
-from sleekxmpp.plugins.xep_0009.binding import py2xml
+from sleekxmpp.plugins.xep_0009.binding import py2xml, xml2py, rpcbase64, \
+    rpctime
 from sleekxmpp.stanza.iq import Iq
 from sleekxmpp.test.sleektest import SleekTest
 from sleekxmpp.xmlstream.stanzabase import register_stanza_plugin
+from sleekxmpp.xmlstream.tostring import tostring
 import unittest
 
 
 
 class TestJabberRPC(SleekTest):
-   
+
     def setUp(self):
         register_stanza_plugin(Iq, RPCQuery)
-        register_stanza_plugin(RPCQuery, MethodCall)    
+        register_stanza_plugin(RPCQuery, MethodCall)
         register_stanza_plugin(RPCQuery, MethodResponse)
-        
+
     def testMethodCall(self):
         iq = self.Iq()
         iq['rpc_query']['method_call']['method_name'] = 'system.exit'
@@ -50,6 +54,235 @@ class TestJabberRPC(SleekTest):
                 </query>
             </iq>
         """, use_values=False)
-        
-suite = unittest.TestLoader().loadTestsFromTestCase(TestJabberRPC)        
-        
+
+    def testConvertNil(self):
+        params = [None]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <nil />
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "Nil to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(params, xml2py(expected_xml),
+                         "XML to nil conversion")
+
+    def testConvertBoolean(self):
+        params = [True, False]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <boolean>1</boolean>
+                    </value>
+                </param>
+                <param>
+                    <value>
+                        <boolean>0</boolean>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "Boolean to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(params, xml2py(expected_xml),
+                         "XML to boolean conversion")
+
+    def testConvertString(self):
+        params = ["'This' & \"That\""]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <string>&apos;This&apos; &amp; &quot;That&quot;</string>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "String to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(params, xml2py(expected_xml),
+                        "XML to string conversion")
+
+    def testConvertInteger(self):
+        params = [32767, -32768]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <i4>32767</i4>
+                    </value>
+                </param>
+                <param>
+                    <value>
+                        <i4>-32768</i4>
+                    </value>
+                </param>
+            </params>
+        """)
+        alternate_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <int>32767</int>
+                    </value>
+                </param>
+                <param>
+                    <value>
+                        <int>-32768</int>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "Integer to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(params, xml2py(expected_xml),
+                         "XML to boolean conversion")
+        self.assertEqual(params, xml2py(alternate_xml),
+                         "Alternate XML to boolean conversion")
+
+
+    def testConvertDouble(self):
+        params = [3.14159265]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <double>3.14159265</double>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "Double to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(params, xml2py(expected_xml),
+                         "XML to double conversion")
+
+    def testConvertBase64(self):
+        params = [rpcbase64(base64.encodestring("Hello, world!"))]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <base64>SGVsbG8sIHdvcmxkIQ==</base64>
+                    </value>
+                </param>
+            </params>
+        """)
+        alternate_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <Base64>SGVsbG8sIHdvcmxkIQ==</Base64>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "Base64 to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(map(lambda x: x.decode(), params),
+                         map(lambda x: x.decode(), xml2py(expected_xml)),
+                         "XML to base64 conversion")
+        self.assertEqual(map(lambda x: x.decode(), params),
+                         map(lambda x: x.decode(), xml2py(alternate_xml)),
+                         "Alternate XML to base64 conversion")
+
+    def testConvertDateTime(self):
+        params = [rpctime("20111220T01:50:00")]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <dateTime.iso8601>20111220T01:50:00</dateTime.iso8601>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "DateTime to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(map(lambda x: x.iso8601(), params),
+                         map(lambda x: x.iso8601(), xml2py(expected_xml)),
+                         None)
+
+    def testConvertArray(self):
+        params = [[1,2,3], ('a', 'b', 'c')]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <array>
+                            <data>
+                                <value><i4>1</i4></value>
+                                <value><i4>2</i4></value>
+                                <value><i4>3</i4></value>
+                            </data>
+                        </array>
+                    </value>
+                </param>
+                <param>
+                    <value>
+                        <array>
+                            <data>
+                                <value><string>a</string></value>
+                                <value><string>b</string></value>
+                                <value><string>c</string></value>
+                            </data>
+                        </array>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "Array to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(map(list, params), xml2py(expected_xml),
+                         "XML to array conversion")
+
+    def testConvertStruct(self):
+        params = [{"foo": "bar", "baz": False}]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <struct>
+                            <member>
+                                <name>foo</name>
+                                <value><string>bar</string></value>
+                            </member>
+                            <member>
+                                <name>baz</name>
+                                <value><boolean>0</boolean></value>
+                            </member>
+                        </struct>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.failUnless(self.compare(expected_xml, params_xml),
+                        "Struct to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(params, xml2py(expected_xml),
+                         "XML to struct conversion")
+
+suite = unittest.TestLoader().loadTestsFromTestCase(TestJabberRPC)
+


### PR DESCRIPTION
I've corrected the broken boolean conversion referenced in issue #123, and added unit tests to validate conversions to and from XML-RPC and Python values.

The tests uncovered an error in the XML-RPC dateTime value conversion, which I also fixed (it was passing the whole element through to the rpctime constructor, rather than the string contents as it should have).
