### PR TITLE
Use jid.bare as a key instead of a JID instance.

### DIFF
--- a/sleekxmpp/roster/single.py
+++ b/sleekxmpp/roster/single.py
@@ -152,11 +152,11 @@ class RosterNode(object):
                  'pending_out': pending_out,
                  'whitelisted': whitelisted,
                  'subscription': 'none'}
-        self._jids[jid] = RosterItem(self.xmpp, jid, self.jid,
+        self._jids[key] = RosterItem(self.xmpp, jid, self.jid,
                                      state=state, db=self.db,
                                      roster=self)
         if save:
-            self._jids[jid].save()
+            self._jids[key].save()
 
     def subscribe(self, jid):
         """


### PR DESCRIPTION
The variable key was set but then unused.
