### PR TITLE
Fix ValueError when line has more than one '='.

### DIFF
--- a/sleekxmpp/thirdparty/suelta/mechanisms/google_token.py
+++ b/sleekxmpp/thirdparty/suelta/mechanisms/google_token.py
@@ -42,7 +42,7 @@ class X_GOOGLE_TOKEN(Mechanism):
                 resp = conn.getresponse().read()
                 data = {}
                 for line in resp.split():
-                    k, v = line.split(b'=')
+                    k, v = line.split(b'=', 1)
                     data[k] = v
             except Exception as e:
                 raise e


### PR DESCRIPTION
_Maybe I should send this to the Suelta project?!_

It can be the case that an HTTP value has an equal sign.

For example, trying to connect to a random Google Account with a bogus password gives something like this:

```
>>> resp = conn.getresponse().read()
>>> print resp
CaptchaToken=dt_qNdQivgzadARm_W84FpRAOVaGwRk3chGurwaKCDrvQWs4sHoNCfqajOmMpPeU_J5
NhEX6EGL_rhIniRfmGY5VFm1YNxuM3wHK_A8lshY:yaz4IUGHxxM7JyKk5DlNbA
CaptchaUrl=Captcha?ctoken=dt_qNdQivgzadARm_W84FpRAOVaGwRk3chGurwaKCDrvQWs4sHoNCf
qajOmMpPeU_J5NhEX6EGL_rhIniRfmGY5VFm1YNxuM3wHK_A8lshY%3Ayaz4IUGHxxM7JyKk5DlNbA
Error=CaptchaRequired
Url=https://www.google.com/accounts/ErrorMsg?Email=paulo%40gmail.com&service=mai
l&id=cr&timeStmp=1327263739&secTok=.AG5fkS-7qwzHM3hAQTEYfnfeipHz1irYCg%3D%3D
```

Note the `CaptchaUrl' line.

Apparently, this "CaptchaRequired" error is not yet handled.
