### PR TITLE
Fix RPC examples

### DIFF
--- a/examples/rpc_client_side.py
+++ b/examples/rpc_client_side.py
@@ -16,7 +16,7 @@ class Thermostat(Endpoint):
     def FQN(self):
         return 'thermostat'
     
-    def __init(self, initial_temperature):
+    def __init__(self, initial_temperature):
         self._temperature = initial_temperature
         self._event = threading.Event()        
     

--- a/examples/rpc_server_side.py
+++ b/examples/rpc_server_side.py
@@ -15,7 +15,7 @@ class Thermostat(Endpoint):
     def FQN(self):
         return 'thermostat'
     
-    def __init(self, initial_temperature):
+    def __init__(self, initial_temperature):
         self._temperature = initial_temperature
         self._event = threading.Event()        
     


### PR DESCRIPTION
rpc examples were broken because **init** in rpc_client_side.py and rpc_server_side.py was named **init instead of __init**
