### PR TITLE
Updated XEP-0009 to handle unicode strings

### DIFF
--- a/sleekxmpp/plugins/xep_0009/binding.py
+++ b/sleekxmpp/plugins/xep_0009/binding.py
@@ -54,7 +54,7 @@ def _py2xml(*args):
             boolean = ET.Element("{%s}boolean" % _namespace)
             boolean.text = str(int(x))
             val.append(boolean)
-        elif type(x) is str:
+        elif type(x) in (str, unicode):
             string = ET.Element("{%s}string" % _namespace)
             string.text = x
             val.append(string)

--- a/tests/test_stanza_xep_0009.py
+++ b/tests/test_stanza_xep_0009.py
@@ -1,3 +1,5 @@
+# -*- encoding:utf-8 -*-
+
 """
     SleekXMPP: The Sleek XMPP Library
     Copyright (C) 2011 Nathanael C. Fritz, Dann Martens (TOMOTON).
@@ -104,6 +106,24 @@ class TestJabberRPC(SleekTest):
                 <param>
                     <value>
                         <string>&apos;This&apos; &amp; &quot;That&quot;</string>
+                    </value>
+                </param>
+            </params>
+        """)
+        self.assertTrue(self.compare(expected_xml, params_xml),
+                        "String to XML conversion\nExpected: %s\nGot: %s" % (
+                            tostring(expected_xml), tostring(params_xml)))
+        self.assertEqual(params, xml2py(expected_xml),
+                        "XML to string conversion")
+
+    def testConvertUnicodeString(self):
+        params = [u"おはよう"]
+        params_xml = py2xml(*params)
+        expected_xml = self.parse_xml("""
+            <params xmlns="jabber:iq:rpc">
+                <param>
+                    <value>
+                        <string>おはよう</string>
                     </value>
                 </param>
             </params>


### PR DESCRIPTION
Changed the python value -> XMLRPC value converter to support unicode strings, and added an additional unit test.

Previously, outgoing unicode strings would be converted to empty <value /> elements, which the XMLRPC client would then choke on.
