### PR TITLE
xep_0065 plugin (Socks5 Bytestreams)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/_build/
 .tox/
 .coverage
 sleekxmpp.egg-info/
+.ropeproject/

--- a/LICENSE
+++ b/LICENSE
@@ -69,8 +69,8 @@ modification, are permitted provided that the following conditions are met:
     * Redistributions in binary form must reproduce the above copyright
       notice, this list of conditions and the following disclaimer in the
       documentation and/or other materials provided with the distribution.
-    * Neither the name of Red Innovation nor the names of its contributors 
-      may be used to endorse or promote products derived from this software 
+    * Neither the name of Red Innovation nor the names of its contributors
+      may be used to endorse or promote products derived from this software
       without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY RED INNOVATION ``AS IS'' AND ANY
@@ -167,3 +167,28 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+socksipy: A Python SOCKS client module.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Copyright 2006 Dan-Haim. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of Dan Haim nor the names of his contributors may be used
+   to endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY DAN HAIM "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL DAN HAIM OR HIS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMANGE.

--- a/sleekxmpp/plugins/xep_0065/__init__.py
+++ b/sleekxmpp/plugins/xep_0065/__init__.py
@@ -1,0 +1,8 @@
+"""
+"""
+
+from sleekxmpp.plugins.base import register_plugin
+from sleekxmpp.plugins.xep_0065.proxy import xep_0065
+
+
+register_plugin(xep_0065)

--- a/sleekxmpp/plugins/xep_0065/__init__.py
+++ b/sleekxmpp/plugins/xep_0065/__init__.py
@@ -1,6 +1,3 @@
-"""
-"""
-
 from sleekxmpp.plugins.base import register_plugin
 from sleekxmpp.plugins.xep_0065.proxy import xep_0065
 

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 
 class xep_0065(base_plugin):
     """
-    XEP-0065 In-Band Bytestreams
+    XEP-0065 Socks5 Bytestreams
     """
 
     description = "Socks5 Bytestreams"
@@ -40,13 +40,13 @@ class xep_0065(base_plugin):
 
         # Handler for the streamhost stanza.
         self.xmpp.registerHandler(
-            Callback('In-Band Bytestreams',
+            Callback('Socks5 Bytestreams',
                      StanzaPath('iq@type=set/q/streamhost'),
                      self._handle_streamhost))
 
         # Handler for the streamhost-used stanza.
         self.xmpp.registerHandler(
-            Callback('In-Band Bytestreams',
+            Callback('Socks5 Bytestreams',
                      StanzaPath('iq@type=result/q/streamhost-used'),
                      self._handle_streamhost_used))
 

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -7,12 +7,12 @@ from hashlib import sha1
 from select import select
 from uuid import uuid4
 
+import stanza
+
 from sleekxmpp.plugins.base import base_plugin
 from sleekxmpp.xmlstream.handler import Callback
 from sleekxmpp.xmlstream.matcher import StanzaPath
-from socks import socksocket, PROXY_TYPE_SOCKS5
-
-import stanza
+from sleekxmpp.thirdparty.socks import socksocket, PROXY_TYPE_SOCKS5
 
 # Registers the sleekxmpp logger
 log = logging.getLogger(__name__)

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -214,6 +214,12 @@ class xep_0065(base_plugin):
     def on_recv(self, sid, data):
         """ Calls when data is recv from the Proxy socket associated
         to the SID.
+
+        Triggers a socks_closed event if the socket is closed. The sid
+        is passed to this event.
+
+        Triggers a socks_recv event if there's available data. A dict
+        that contains the sid and the data is passed to this event.
         """
 
         proxy = self.proxy_threads.get(sid)
@@ -221,7 +227,7 @@ class xep_0065(base_plugin):
             if not data:
                 self.xmpp.event('socks_closed', sid)
             else:
-                self.xmpp.event('socks_recv', data)
+                self.xmpp.event('socks_recv', {'sid': sid, 'data': data})
 
 
 class Proxy(Thread):

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -1,0 +1,300 @@
+import sys
+import logging
+import struct
+
+from threading import Thread, Event
+from hashlib import sha1
+from select import select
+from uuid import uuid4
+
+from sleekxmpp.plugins.base import base_plugin
+from sleekxmpp import Iq
+from sleekxmpp.xmlstream import register_stanza_plugin
+from sleekxmpp.xmlstream.handler import Callback
+from sleekxmpp.xmlstream.matcher import StanzaPath
+
+from socks import socksocket, PROXY_TYPE_SOCKS5
+
+from stanza import Query, StreamHost, StreamHostUsed
+
+# Register the sleekxmpp logger
+log = logging.getLogger(__name__)
+
+# Register xep_0065 stanzas
+register_stanza_plugin(Iq, Query)
+register_stanza_plugin(Query, StreamHost)
+register_stanza_plugin(Query, StreamHostUsed)
+
+
+class xep_0065(base_plugin):
+    """
+    XEP-0065 In-Band Bytestreams
+    """
+
+    description = "In-Band Bytestreams"
+    dependencies = set(['xep_0030', ])
+    xep = '0065'
+
+    def plugin_init(self):
+        """ Initializes the xep_0065 plugin and all event callbacks.
+        """
+
+        # Shortcuts to access to the xep_0030 plugin.
+        self.disco = self.xmpp['xep_0030']
+
+        # Handler for the streamhost stanza.
+        self.xmpp.registerHandler(
+            Callback('In-Band Bytestreams',
+                     StanzaPath('iq@type=set/q/streamhost'),
+                     self._handle_streamhost))
+
+        # Handler for the streamhost-used stanza.
+        self.xmpp.registerHandler(
+            Callback('In-Band Bytestreams',
+                     StanzaPath('iq@type=result/q/streamhost-used'),
+                     self._handle_streamhost_used))
+
+    def handshake(self, to, streamer=None):
+        """ Starts the handshake to establish the socks5 bytestreams
+        connection.
+        """
+
+        # Discovers the proxy.
+        self.streamer = streamer or self.discover_proxy()
+
+        # Requester requests network address from the proxy.
+        streamhost = self.get_network_address(self.streamer)
+        self.proxy_host = streamhost['q']['streamhost']['host']
+        self.proxy_port = streamhost['q']['streamhost']['port']
+
+        # Generates the SID for this new handshake.
+        sid = uuid4().hex
+
+        # Requester initiates S5B negotation with Target by sending
+        # IQ-set that includes the JabberID and network address of
+        # StreamHost as well as the StreamID (SID) of the proposed
+        # bytestream.
+        iq = self.xmpp.Iq(sto=to, stype='set')
+        iq['q']['sid'] = sid
+        iq['q']['streamhost']['jid'] = self.streamer
+        iq['q']['streamhost']['host'] = self.proxy_host
+        iq['q']['streamhost']['port'] = self.proxy_port
+
+        # Sends the new IQ.
+        return iq.send()
+
+    def discover_proxy(self):
+        """ Auto-discovers (using XEP 0030) the available bytestream
+        proxy on the XMPP server.
+
+        Returns the JID of the proxy.
+        """
+
+        # Gets all disco items.
+        disco_items = self.disco.get_items(self.xmpp.server)
+
+        for item in disco_items['disco_items']['items']:
+            # For each items, gets the disco info.
+            disco_info = self.disco.get_info(item[0])
+
+            # Gets and verifies if the identity is a bytestream proxy.
+            identities = disco_info['disco_info']['identities']
+            for identity in identities:
+                if identity[0] == 'proxy' and identity[1] == 'bytestreams':
+                    # Returns when the first occurence is found.
+                    return '%s' % disco_info['from']
+
+    def get_network_address(self, streamer):
+        iq = self.xmpp.Iq(sto=streamer, stype='get')
+        iq['q']
+
+        return iq.send()
+
+    def _handle_streamhost(self, iq):
+        """ Handles all streamhost stanzas.
+        """
+
+        # Registers the streamhost info.
+        self.streamer = iq['q']['streamhost']['jid']
+        self.proxy_host = iq['q']['streamhost']['host']
+        self.proxy_port = iq['q']['streamhost']['port']
+
+        # Sets the SID, the requester and the target.
+        sid = iq['q']['sid']
+        requester = '%s' % iq['from']
+        target = '%s' % self.xmpp.boundjid
+
+        # Next the Target attempts to open a standard TCP socket on
+        # the network address of the Proxy.
+        self.target_thread = Proxy(sid, requester, target, self.proxy_host,
+                                   self.proxy_port, self._handle_on_recv)
+        self.target_thread.start()
+
+        # Wait until the proxy is connected
+        self.target_thread.connected.wait()
+
+        # Replies to the incoming iq with a streamhost-used stanza.
+        res_iq = iq.reply()
+        res_iq['q']['sid'] = sid
+        res_iq['q']['streamhost-used']['jid'] = self.streamer
+
+        # Sends the IQ
+        return res_iq.send()
+
+    def _handle_streamhost_used(self, iq):
+        """ Handles all streamhost-used stanzas.
+        """
+
+        # Sets the requester and the target.
+        requester = '%s' % self.xmpp.boundjid
+        target  = '%s' % iq['from']
+
+        # The Requester will establish a connection to the SOCKS5
+        # proxy in the same way the Target did.
+        self.requester_thread = Proxy(iq['q']['sid'], requester, target,
+                                      self.proxy_host, self.proxy_port,
+                                      self._handle_on_recv)
+        self.requester_thread.start()
+
+        # Wait until the proxy is connected
+        self.requester_thread.connected.wait()
+
+        # Requester sends IQ-set to StreamHost requesting that
+        # StreamHost activate the bytestream associated with the
+        # StreamID.
+        self.activate(iq['q']['sid'], target)
+
+    def activate(self, sid, to):
+        """ IQ-set to StreamHost requesting that StreamHost activate
+        the bytestream associated with the StreamID.
+        """
+
+        # Creates the activate IQ.
+        act_iq = self.xmpp.Iq(sto=self.streamer, stype='set')
+        act_iq['q']['sid'] = sid
+        act_iq['q']['activate'] = to
+
+        # Send the IQ.
+        act_iq.send()
+
+    def send(self, msg):
+        """ Sends the msg to the socket.
+
+        msg : The message data.
+        """
+
+        if hasattr(self, 'requester_thread'):
+            self.requester_thread.send(msg)
+        elif hasattr(self, 'target_thread'):
+            self.target_thread.send(msg)
+
+    def _handle_on_recv(self, data):
+        """ A default callback when socket are receiving data.
+        """
+
+        log.debug('Received: %s' % data)
+
+
+class Proxy(Thread):
+
+    def __init__(self, sid, requester, target, proxy, proxy_port,
+                 on_recv):
+        """ Initializes the proxy thread.
+
+        sid        : The StreamID. <str>
+        requester  : The JID of the requester. <str>
+        target     : The JID of the target. <str>
+        proxy_host : The hostname or the IP of the proxy. <str>
+        proxy_port : The port of the proxy. <str> or <int>
+        on_recv    : A callback called when data are received from the
+                     socket. <Callable>
+        """
+
+        # Initializes the thread.
+        Thread.__init__(self)
+
+        # Because the xep_0065 plugin uses the proxy_port as string,
+        # the Proxy class accepts the proxy_port argument as a string
+        # or an integer. Here, we force to use the port as an integer.
+        proxy_port = int(proxy_port)
+
+        # Creates a connected event to warn when to proxy is
+        # connected.
+        self.connected = Event()
+
+        # Registers the arguments.
+        self.sid = sid
+        self.requester = requester
+        self.target = target
+        self.proxy = proxy
+        self.proxy_port = proxy_port
+        self.on_recv = on_recv
+
+    def run(self):
+        """ Starts the thread.
+        """
+
+        # Creates the socks5 proxy socket
+        self.s = socksocket()
+        self.s.setproxy(PROXY_TYPE_SOCKS5, self.proxy, port=self.proxy_port)
+
+        # The hostname MUST be SHA1(SID + Requester JID + Target JID)
+        # where the output is hexadecimal-encoded (not binary).
+        digest = sha1()
+        digest.update(self.sid)  # SID
+        digest.update(self.requester)  # Requester JID
+        digest.update(self.target)  # Target JID
+
+        # Computes the digest in hex.
+        dest = '%s' % digest.hexdigest()
+
+        # The port MUST be 0.
+        self.s.connect((dest, 0))
+        log.info('Connected')
+        self.connected.set()
+
+        # Listen for data on the socket
+        self.listen()
+
+    def listen(self):
+        """ Listen for data on the socket. When receiving data, call
+        the callback on_recv callable.
+        """
+
+        while True:
+            ins, out, err = select([self.s, ], [], [])
+
+            for s in ins:
+                data = self.recv_size(self.s)
+                self.on_recv(data)
+
+    def recv_size(self, the_socket):
+        #data length is packed into 4 bytes
+        total_len = 0
+        total_data = []
+        size = sys.maxint
+        size_data = sock_data = ''
+        recv_size = 8192
+
+        while total_len < size:
+            sock_data = the_socket.recv(recv_size)
+            if not total_data:
+                if len(sock_data) > 4:
+                    size_data += sock_data
+                    size = struct.unpack('>i', size_data[:4])[0]
+                    recv_size = size
+                    if recv_size > 524288:
+                        recv_size = 524288
+                    total_data.append(size_data[4:])
+                else:
+                    size_data += sock_data
+            else:
+                total_data.append(sock_data)
+            total_len = sum([len(i) for i in total_data])
+        return ''.join(total_data)
+
+    def send(self, msg):
+        """ Sends the data over the socket.
+        """
+
+        self.s.sendall(msg)

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -23,7 +23,7 @@ class xep_0065(base_plugin):
     XEP-0065 In-Band Bytestreams
     """
 
-    description = "In-Band Bytestreams"
+    description = "Socks5 Bytestreams"
     dependencies = set(['xep_0030', ])
     xep = '0065'
 

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -97,8 +97,13 @@ class xep_0065(base_plugin):
                     return '%s' % disco_info['from']
 
     def get_network_address(self, streamer):
+        """ Gets the streamhost information of the proxy.
+
+        streamer : The jid of the proxy.
+        """
+
         iq = self.xmpp.Iq(sto=streamer, stype='get')
-        iq['q']
+        iq['q']  # Adds the query eleme to the iq.
 
         return iq.send()
 

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -51,6 +51,14 @@ class xep_0065(base_plugin):
                      StanzaPath('iq@type=result/socks/streamhost-used'),
                      self._handle_streamhost_used))
 
+    def get_socket(self, sid):
+        """ Returns the socket associated to the SID.
+        """
+
+        proxy = self.proxy_threads.get(sid)
+        if proxy:
+            return proxy.s
+
     def handshake(self, to, streamer=None):
         """ Starts the handshake to establish the socks5 bytestreams
         connection.

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -42,13 +42,13 @@ class xep_0065(base_plugin):
         # Handler for the streamhost stanza.
         self.xmpp.registerHandler(
             Callback('Socks5 Bytestreams',
-                     StanzaPath('iq@type=set/q/streamhost'),
+                     StanzaPath('iq@type=set/socks/streamhost'),
                      self._handle_streamhost))
 
         # Handler for the streamhost-used stanza.
         self.xmpp.registerHandler(
             Callback('Socks5 Bytestreams',
-                     StanzaPath('iq@type=result/q/streamhost-used'),
+                     StanzaPath('iq@type=result/socks/streamhost-used'),
                      self._handle_streamhost_used))
 
     def handshake(self, to, streamer=None):
@@ -61,8 +61,8 @@ class xep_0065(base_plugin):
 
         # Requester requests network address from the proxy.
         streamhost = self.get_network_address(self.streamer)
-        self.proxy_host = streamhost['q']['streamhost']['host']
-        self.proxy_port = streamhost['q']['streamhost']['port']
+        self.proxy_host = streamhost['socks']['streamhost']['host']
+        self.proxy_port = streamhost['socks']['streamhost']['port']
 
         # Generates the SID for this new handshake.
         sid = uuid4().hex
@@ -72,10 +72,10 @@ class xep_0065(base_plugin):
         # StreamHost as well as the StreamID (SID) of the proposed
         # bytestream.
         iq = self.xmpp.Iq(sto=to, stype='set')
-        iq['q']['sid'] = sid
-        iq['q']['streamhost']['jid'] = self.streamer
-        iq['q']['streamhost']['host'] = self.proxy_host
-        iq['q']['streamhost']['port'] = self.proxy_port
+        iq['socks']['sid'] = sid
+        iq['socks']['streamhost']['jid'] = self.streamer
+        iq['socks']['streamhost']['host'] = self.proxy_host
+        iq['socks']['streamhost']['port'] = self.proxy_port
 
         # Sends the new IQ.
         return iq.send()
@@ -108,7 +108,7 @@ class xep_0065(base_plugin):
         """
 
         iq = self.xmpp.Iq(sto=streamer, stype='get')
-        iq['q']  # Adds the query eleme to the iq.
+        iq['socks']  # Adds the query eleme to the iq.
 
         return iq.send()
 
@@ -117,12 +117,12 @@ class xep_0065(base_plugin):
         """
 
         # Registers the streamhost info.
-        self.streamer = iq['q']['streamhost']['jid']
-        self.proxy_host = iq['q']['streamhost']['host']
-        self.proxy_port = iq['q']['streamhost']['port']
+        self.streamer = iq['socks']['streamhost']['jid']
+        self.proxy_host = iq['socks']['streamhost']['host']
+        self.proxy_port = iq['socks']['streamhost']['port']
 
         # Sets the SID, the requester and the target.
-        sid = iq['q']['sid']
+        sid = iq['socks']['sid']
         requester = '%s' % iq['from']
         target = '%s' % self.xmpp.boundjid
 
@@ -140,8 +140,8 @@ class xep_0065(base_plugin):
 
         # Replies to the incoming iq with a streamhost-used stanza.
         res_iq = iq.reply()
-        res_iq['q']['sid'] = sid
-        res_iq['q']['streamhost-used']['jid'] = self.streamer
+        res_iq['socks']['sid'] = sid
+        res_iq['socks']['streamhost-used']['jid'] = self.streamer
 
         # Sends the IQ
         return res_iq.send()
@@ -151,7 +151,7 @@ class xep_0065(base_plugin):
         """
 
         # Sets the SID, the requester and the target.
-        sid = iq['q']['sid']
+        sid = iq['socks']['sid']
         requester = '%s' % self.xmpp.boundjid
         target  = '%s' % iq['from']
 
@@ -170,7 +170,7 @@ class xep_0065(base_plugin):
         # Requester sends IQ-set to StreamHost requesting that
         # StreamHost activate the bytestream associated with the
         # StreamID.
-        self.activate(iq['q']['sid'], target)
+        self.activate(iq['socks']['sid'], target)
 
     def activate(self, sid, to):
         """ IQ-set to StreamHost requesting that StreamHost activate
@@ -179,8 +179,8 @@ class xep_0065(base_plugin):
 
         # Creates the activate IQ.
         act_iq = self.xmpp.Iq(sto=self.streamer, stype='set')
-        act_iq['q']['sid'] = sid
-        act_iq['q']['activate'] = to
+        act_iq['socks']['sid'] = sid
+        act_iq['socks']['activate'] = to
 
         # Send the IQ.
         act_iq.send()

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -8,22 +8,14 @@ from select import select
 from uuid import uuid4
 
 from sleekxmpp.plugins.base import base_plugin
-from sleekxmpp import Iq
-from sleekxmpp.xmlstream import register_stanza_plugin
 from sleekxmpp.xmlstream.handler import Callback
 from sleekxmpp.xmlstream.matcher import StanzaPath
-
 from socks import socksocket, PROXY_TYPE_SOCKS5
 
-from stanza import Query, StreamHost, StreamHostUsed
+import stanza
 
-# Register the sleekxmpp logger
+# Registers the sleekxmpp logger
 log = logging.getLogger(__name__)
-
-# Register xep_0065 stanzas
-register_stanza_plugin(Iq, Query)
-register_stanza_plugin(Query, StreamHost)
-register_stanza_plugin(Query, StreamHostUsed)
 
 
 class xep_0065(base_plugin):

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -26,6 +26,7 @@ class xep_0065(base_plugin):
     description = "Socks5 Bytestreams"
     dependencies = set(['xep_0030', ])
     xep = '0065'
+    name = 'xep_0065'
 
     # A dict contains for each SID, the proxy thread currently
     # running.

--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -217,7 +217,10 @@ class xep_0065(base_plugin):
 
         proxy = self.proxy_threads.get(sid)
         if proxy:
-            self.xmpp.event('socks_recv', data)
+            if not data:
+                self.xmpp.event('socks_closed', sid)
+            else:
+                self.xmpp.event('socks_recv', data)
 
 
 class Proxy(Thread):

--- a/sleekxmpp/plugins/xep_0065/stanza.py
+++ b/sleekxmpp/plugins/xep_0065/stanza.py
@@ -1,0 +1,38 @@
+from sleekxmpp.xmlstream import ElementBase
+
+# The protocol namespace defined in the Socks5Bytestream (0065) spec.
+namespace = 'http://jabber.org/protocol/bytestreams'
+
+
+class StreamHost(ElementBase):
+    """ The streamhost xml element.
+    """
+
+    namespace = namespace
+    name = 'streamhost'
+    plugin_attrib = 'streamhost'
+    interfaces = set(('host', 'jid', 'port'))
+
+
+class StreamHostUsed(ElementBase):
+    """ The streamhost-used xml element.
+    """
+
+    namespace = 'http://jabber.org/protocol/bytestreams'
+    name = 'streamhost-used'
+    plugin_attrib = 'streamhost-used'
+    interfaces = set(('jid',))
+
+
+class Query(ElementBase):
+    """ The query xml element.
+    """
+
+    namespace = 'http://jabber.org/protocol/bytestreams'
+    name = 'query'
+    plugin_attrib = 'q'
+    interfaces = set(('sid', 'activate'))
+    sub_interfaces = set(('activate',))
+
+
+

--- a/sleekxmpp/plugins/xep_0065/stanza.py
+++ b/sleekxmpp/plugins/xep_0065/stanza.py
@@ -26,16 +26,16 @@ class StreamHostUsed(ElementBase):
     interfaces = set(('jid',))
 
 
-class Query(ElementBase):
+class Socks5(ElementBase):
     """ The query xml element.
     """
 
     namespace = namespace
     name = 'query'
-    plugin_attrib = 'q'
+    plugin_attrib = 'socks'
     interfaces = set(('sid', 'activate'))
     sub_interfaces = set(('activate',))
 
-register_stanza_plugin(Iq, Query)
-register_stanza_plugin(Query, StreamHost)
-register_stanza_plugin(Query, StreamHostUsed)
+register_stanza_plugin(Iq, Socks5)
+register_stanza_plugin(Socks5, StreamHost)
+register_stanza_plugin(Socks5, StreamHostUsed)

--- a/sleekxmpp/plugins/xep_0065/stanza.py
+++ b/sleekxmpp/plugins/xep_0065/stanza.py
@@ -1,4 +1,6 @@
-from sleekxmpp.xmlstream import ElementBase
+from sleekxmpp import Iq
+from sleekxmpp.xmlstream import ElementBase, register_stanza_plugin
+
 
 # The protocol namespace defined in the Socks5Bytestream (0065) spec.
 namespace = 'http://jabber.org/protocol/bytestreams'
@@ -34,5 +36,6 @@ class Query(ElementBase):
     interfaces = set(('sid', 'activate'))
     sub_interfaces = set(('activate',))
 
-
-
+register_stanza_plugin(Iq, Query)
+register_stanza_plugin(Query, StreamHost)
+register_stanza_plugin(Query, StreamHostUsed)

--- a/sleekxmpp/plugins/xep_0065/stanza.py
+++ b/sleekxmpp/plugins/xep_0065/stanza.py
@@ -18,7 +18,7 @@ class StreamHostUsed(ElementBase):
     """ The streamhost-used xml element.
     """
 
-    namespace = 'http://jabber.org/protocol/bytestreams'
+    namespace = namespace
     name = 'streamhost-used'
     plugin_attrib = 'streamhost-used'
     interfaces = set(('jid',))
@@ -28,7 +28,7 @@ class Query(ElementBase):
     """ The query xml element.
     """
 
-    namespace = 'http://jabber.org/protocol/bytestreams'
+    namespace = namespace
     name = 'query'
     plugin_attrib = 'q'
     interfaces = set(('sid', 'activate'))

--- a/sleekxmpp/thirdparty/__init__.py
+++ b/sleekxmpp/thirdparty/__init__.py
@@ -8,5 +8,5 @@ try:
 except:
     from sleekxmpp.thirdparty.gnupg import GPG
 
-from sleekxmpp.thirdparty import suelta
+from sleekxmpp.thirdparty import suelta, socks
 from sleekxmpp.thirdparty.mini_dateutil import tzutc, tzoffset, parse_iso

--- a/sleekxmpp/thirdparty/socks.py
+++ b/sleekxmpp/thirdparty/socks.py
@@ -1,0 +1,382 @@
+"""SocksiPy - Python SOCKS module.
+Version 1.00
+
+Copyright 2006 Dan-Haim. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of Dan Haim nor the names of his contributors may be used
+   to endorse or promote products derived from this software without specific
+   prior written permission.
+   
+THIS SOFTWARE IS PROVIDED BY DAN HAIM "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
+EVENT SHALL DAN HAIM OR HIS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMANGE.
+
+
+This module provides a standard socket-like interface for Python
+for tunneling connections through SOCKS proxies.
+
+"""
+
+"""
+
+Minor modifications made by Christopher Gilbert (http://motomastyle.com/)
+for use in PyLoris (http://pyloris.sourceforge.net/)
+
+Minor modifications made by Mario Vilas (http://breakingcode.wordpress.com/)
+mainly to merge bug fixes found in Sourceforge
+
+"""
+
+import socket
+import struct
+import sys
+
+PROXY_TYPE_SOCKS4 = 1
+PROXY_TYPE_SOCKS5 = 2
+PROXY_TYPE_HTTP = 3
+
+_defaultproxy = None
+_orgsocket = socket.socket
+
+class ProxyError(Exception): pass
+class GeneralProxyError(ProxyError): pass
+class Socks5AuthError(ProxyError): pass
+class Socks5Error(ProxyError): pass
+class Socks4Error(ProxyError): pass
+class HTTPError(ProxyError): pass
+
+_generalerrors = ("success",
+    "invalid data",
+    "not connected",
+    "not available",
+    "bad proxy type",
+    "bad input")
+
+_socks5errors = ("succeeded",
+    "general SOCKS server failure",
+    "connection not allowed by ruleset",
+    "Network unreachable",
+    "Host unreachable",
+    "Connection refused",
+    "TTL expired",
+    "Command not supported",
+    "Address type not supported",
+    "Unknown error")
+
+_socks5autherrors = ("succeeded",
+    "authentication is required",
+    "all offered authentication methods were rejected",
+    "unknown username or invalid password",
+    "unknown error")
+
+_socks4errors = ("request granted",
+    "request rejected or failed",
+    "request rejected because SOCKS server cannot connect to identd on the client",
+    "request rejected because the client program and identd report different user-ids",
+    "unknown error")
+
+def setdefaultproxy(proxytype=None, addr=None, port=None, rdns=True, username=None, password=None):
+    """setdefaultproxy(proxytype, addr[, port[, rdns[, username[, password]]]])
+    Sets a default proxy which all further socksocket objects will use,
+    unless explicitly changed.
+    """
+    global _defaultproxy
+    _defaultproxy = (proxytype, addr, port, rdns, username, password)
+
+def wrapmodule(module):
+    """wrapmodule(module)
+    Attempts to replace a module's socket library with a SOCKS socket. Must set
+    a default proxy using setdefaultproxy(...) first.
+    This will only work on modules that import socket directly into the namespace;
+    most of the Python Standard Library falls into this category.
+    """
+    if _defaultproxy != None:
+        module.socket.socket = socksocket
+    else:
+        raise GeneralProxyError((4, "no proxy specified"))
+
+class socksocket(socket.socket):
+    """socksocket([family[, type[, proto]]]) -> socket object
+    Open a SOCKS enabled socket. The parameters are the same as
+    those of the standard socket init. In order for SOCKS to work,
+    you must specify family=AF_INET, type=SOCK_STREAM and proto=0.
+    """
+
+    def __init__(self, family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0, _sock=None):
+        _orgsocket.__init__(self, family, type, proto, _sock)
+        if _defaultproxy != None:
+            self.__proxy = _defaultproxy
+        else:
+            self.__proxy = (None, None, None, None, None, None)
+        self.__proxysockname = None
+        self.__proxypeername = None
+
+    def __recvall(self, count):
+        """__recvall(count) -> data
+        Receive EXACTLY the number of bytes requested from the socket.
+        Blocks until the required number of bytes have been received.
+        """
+        data = self.recv(count)
+        while len(data) < count:
+            d = self.recv(count-len(data))
+            if not d: raise GeneralProxyError((0, "connection closed unexpectedly"))
+            data = data + d
+        return data
+
+    def setproxy(self, proxytype=None, addr=None, port=None, rdns=True, username=None, password=None):
+        """setproxy(proxytype, addr[, port[, rdns[, username[, password]]]])
+        Sets the proxy to be used.
+        proxytype -    The type of the proxy to be used. Three types
+                are supported: PROXY_TYPE_SOCKS4 (including socks4a),
+                PROXY_TYPE_SOCKS5 and PROXY_TYPE_HTTP
+        addr -        The address of the server (IP or DNS).
+        port -        The port of the server. Defaults to 1080 for SOCKS
+                servers and 8080 for HTTP proxy servers.
+        rdns -        Should DNS queries be preformed on the remote side
+                (rather than the local side). The default is True.
+                Note: This has no effect with SOCKS4 servers.
+        username -    Username to authenticate with to the server.
+                The default is no authentication.
+        password -    Password to authenticate with to the server.
+                Only relevant when username is also provided.
+        """
+        self.__proxy = (proxytype, addr, port, rdns, username, password)
+
+    def __negotiatesocks5(self, destaddr, destport):
+        """__negotiatesocks5(self,destaddr,destport)
+        Negotiates a connection through a SOCKS5 server.
+        """
+        # First we'll send the authentication packages we support.
+        if (self.__proxy[4]!=None) and (self.__proxy[5]!=None):
+            # The username/password details were supplied to the
+            # setproxy method so we support the USERNAME/PASSWORD
+            # authentication (in addition to the standard none).
+            self.sendall(struct.pack('BBBB', 0x05, 0x02, 0x00, 0x02))
+        else:
+            # No username/password were entered, therefore we
+            # only support connections with no authentication.
+            self.sendall(struct.pack('BBB', 0x05, 0x01, 0x00))
+        # We'll receive the server's response to determine which
+        # method was selected
+        chosenauth = self.__recvall(2)
+        if chosenauth[0:1] != chr(0x05).encode():
+            self.close()
+            raise GeneralProxyError((1, _generalerrors[1]))
+        # Check the chosen authentication method
+        if chosenauth[1:2] == chr(0x00).encode():
+            # No authentication is required
+            pass
+        elif chosenauth[1:2] == chr(0x02).encode():
+            # Okay, we need to perform a basic username/password
+            # authentication.
+            self.sendall(chr(0x01).encode() + chr(len(self.__proxy[4])) + self.__proxy[4] + chr(len(self.__proxy[5])) + self.__proxy[5])
+            authstat = self.__recvall(2)
+            if authstat[0:1] != chr(0x01).encode():
+                # Bad response
+                self.close()
+                raise GeneralProxyError((1, _generalerrors[1]))
+            if authstat[1:2] != chr(0x00).encode():
+                # Authentication failed
+                self.close()
+                raise Socks5AuthError((3, _socks5autherrors[3]))
+            # Authentication succeeded
+        else:
+            # Reaching here is always bad
+            self.close()
+            if chosenauth[1] == chr(0xFF).encode():
+                raise Socks5AuthError((2, _socks5autherrors[2]))
+            else:
+                raise GeneralProxyError((1, _generalerrors[1]))
+        # Now we can request the actual connection
+        req = struct.pack('BBB', 0x05, 0x01, 0x00)
+        # If the given destination address is an IP address, we'll
+        # use the IPv4 address request even if remote resolving was specified.
+        try:
+            ipaddr = socket.inet_aton(destaddr)
+            req = req + chr(0x01).encode() + ipaddr
+        except socket.error:
+            # Well it's not an IP number,  so it's probably a DNS name.
+            if self.__proxy[3]:
+                # Resolve remotely
+                ipaddr = None
+                req = req + chr(0x03).encode() + chr(len(destaddr)).encode() + destaddr
+            else:
+                # Resolve locally
+                ipaddr = socket.inet_aton(socket.gethostbyname(destaddr))
+                req = req + chr(0x01).encode() + ipaddr
+        req = req + struct.pack(">H", destport)
+        self.sendall(req)
+        # Get the response
+        resp = self.__recvall(4)
+        if resp[0:1] != chr(0x05).encode():
+            self.close()
+            raise GeneralProxyError((1, _generalerrors[1]))
+        elif resp[1:2] != chr(0x00).encode():
+            # Connection failed
+            self.close()
+            if ord(resp[1:2])<=8:
+                raise Socks5Error((ord(resp[1:2]), _socks5errors[ord(resp[1:2])]))
+            else:
+                raise Socks5Error((9, _socks5errors[9]))
+        # Get the bound address/port
+        elif resp[3:4] == chr(0x01).encode():
+            boundaddr = self.__recvall(4)
+        elif resp[3:4] == chr(0x03).encode():
+            resp = resp + self.recv(1)
+            boundaddr = self.__recvall(ord(resp[4:5]))
+        else:
+            self.close()
+            raise GeneralProxyError((1,_generalerrors[1]))
+        boundport = struct.unpack(">H", self.__recvall(2))[0]
+        self.__proxysockname = (boundaddr, boundport)
+        if ipaddr != None:
+            self.__proxypeername = (socket.inet_ntoa(ipaddr), destport)
+        else:
+            self.__proxypeername = (destaddr, destport)
+
+    def getproxysockname(self):
+        """getsockname() -> address info
+        Returns the bound IP address and port number at the proxy.
+        """
+        return self.__proxysockname
+
+    def getproxypeername(self):
+        """getproxypeername() -> address info
+        Returns the IP and port number of the proxy.
+        """
+        return _orgsocket.getpeername(self)
+
+    def getpeername(self):
+        """getpeername() -> address info
+        Returns the IP address and port number of the destination
+        machine (note: getproxypeername returns the proxy)
+        """
+        return self.__proxypeername
+
+    def __negotiatesocks4(self,destaddr,destport):
+        """__negotiatesocks4(self,destaddr,destport)
+        Negotiates a connection through a SOCKS4 server.
+        """
+        # Check if the destination address provided is an IP address
+        rmtrslv = False
+        try:
+            ipaddr = socket.inet_aton(destaddr)
+        except socket.error:
+            # It's a DNS name. Check where it should be resolved.
+            if self.__proxy[3]:
+                ipaddr = struct.pack("BBBB", 0x00, 0x00, 0x00, 0x01)
+                rmtrslv = True
+            else:
+                ipaddr = socket.inet_aton(socket.gethostbyname(destaddr))
+        # Construct the request packet
+        req = struct.pack(">BBH", 0x04, 0x01, destport) + ipaddr
+        # The username parameter is considered userid for SOCKS4
+        if self.__proxy[4] != None:
+            req = req + self.__proxy[4]
+        req = req + chr(0x00).encode()
+        # DNS name if remote resolving is required
+        # NOTE: This is actually an extension to the SOCKS4 protocol
+        # called SOCKS4A and may not be supported in all cases.
+        if rmtrslv:
+            req = req + destaddr + chr(0x00).encode()
+        self.sendall(req)
+        # Get the response from the server
+        resp = self.__recvall(8)
+        if resp[0:1] != chr(0x00).encode():
+            # Bad data
+            self.close()
+            raise GeneralProxyError((1,_generalerrors[1]))
+        if resp[1:2] != chr(0x5A).encode():
+            # Server returned an error
+            self.close()
+            if ord(resp[1:2]) in (91, 92, 93):
+                self.close()
+                raise Socks4Error((ord(resp[1:2]), _socks4errors[ord(resp[1:2]) - 90]))
+            else:
+                raise Socks4Error((94, _socks4errors[4]))
+        # Get the bound address/port
+        self.__proxysockname = (socket.inet_ntoa(resp[4:]), struct.unpack(">H", resp[2:4])[0])
+        if rmtrslv != None:
+            self.__proxypeername = (socket.inet_ntoa(ipaddr), destport)
+        else:
+            self.__proxypeername = (destaddr, destport)
+
+    def __negotiatehttp(self, destaddr, destport):
+        """__negotiatehttp(self,destaddr,destport)
+        Negotiates a connection through an HTTP server.
+        """
+        # If we need to resolve locally, we do this now
+        if not self.__proxy[3]:
+            addr = socket.gethostbyname(destaddr)
+        else:
+            addr = destaddr
+        self.sendall(("CONNECT " + addr + ":" + str(destport) + " HTTP/1.1\r\n" + "Host: " + destaddr + "\r\n\r\n").encode())
+        # We read the response until we get the string "\r\n\r\n"
+        resp = self.recv(1)
+        while resp.find("\r\n\r\n".encode()) == -1:
+            resp = resp + self.recv(1)
+        # We just need the first line to check if the connection
+        # was successful
+        statusline = resp.splitlines()[0].split(" ".encode(), 2)
+        if statusline[0] not in ("HTTP/1.0".encode(), "HTTP/1.1".encode()):
+            self.close()
+            raise GeneralProxyError((1, _generalerrors[1]))
+        try:
+            statuscode = int(statusline[1])
+        except ValueError:
+            self.close()
+            raise GeneralProxyError((1, _generalerrors[1]))
+        if statuscode != 200:
+            self.close()
+            raise HTTPError((statuscode, statusline[2]))
+        self.__proxysockname = ("0.0.0.0", 0)
+        self.__proxypeername = (addr, destport)
+
+    def connect(self, destpair):
+        """connect(self, despair)
+        Connects to the specified destination through a proxy.
+        destpar - A tuple of the IP/DNS address and the port number.
+        (identical to socket's connect).
+        To select the proxy server use setproxy().
+        """
+        # Do a minimal input check first
+        if (not type(destpair) in (list,tuple)) or (len(destpair) < 2) or (type(destpair[0]) != type('')) or (type(destpair[1]) != int):
+            raise GeneralProxyError((5, _generalerrors[5]))
+        if self.__proxy[0] == PROXY_TYPE_SOCKS5:
+            if self.__proxy[2] != None:
+                portnum = self.__proxy[2]
+            else:
+                portnum = 1080
+            _orgsocket.connect(self, (self.__proxy[1], portnum))
+            self.__negotiatesocks5(destpair[0], destpair[1])
+        elif self.__proxy[0] == PROXY_TYPE_SOCKS4:
+            if self.__proxy[2] != None:
+                portnum = self.__proxy[2]
+            else:
+                portnum = 1080
+            _orgsocket.connect(self,(self.__proxy[1], portnum))
+            self.__negotiatesocks4(destpair[0], destpair[1])
+        elif self.__proxy[0] == PROXY_TYPE_HTTP:
+            if self.__proxy[2] != None:
+                portnum = self.__proxy[2]
+            else:
+                portnum = 8080
+            _orgsocket.connect(self,(self.__proxy[1], portnum))
+            self.__negotiatehttp(destpair[0], destpair[1])
+        elif self.__proxy[0] == None:
+            _orgsocket.connect(self, (destpair[0], destpair[1]))
+        else:
+            raise GeneralProxyError((4, _generalerrors[4]))


### PR DESCRIPTION
Added the xep_0065 support.

Before merge, two questions:
- This plugin depends on the Socksipy library. Where do I put this dependency ? Having a `requirements.txt` in my xep_0065 package that contains the list of dependencies (here socksipy) will be useful. During the `setup.py install`, SleekXMPP will parse the global `requirements.txt` (with dnspython for example) and all requirements.txt situated in the `plugins/<xep_name>/ folder`. Do you have another idea ?
- For now, my Proxy thread has a `recv_size` method. I think that it's not the role of this plugin to do that. Have you got an alternative to do that ?
