### PR TITLE
support of receipts for clients XEP-0184

### DIFF
--- a/sleekxmpp/plugins/xep_0184/receipt.py
+++ b/sleekxmpp/plugins/xep_0184/receipt.py
@@ -68,7 +68,7 @@ class XEP_0184(BasePlugin):
         ack['to'] = msg['from']
         ack['from'] = msg['to']
         ack['receipt'] = msg['id']
-        ack['id'] = self.xmpp.new_id()
+        ack['id'] = msg['id']
         ack.send()
 
     def _handle_receipt_received(self, msg):


### PR DESCRIPTION
Now psi (and probably miranda) correctly receive delivery receipts.

Regarding to #185

It's hacky, but works.
