### PR TITLE
added setdefaultencoding method so reload(sys) not needed

### DIFF
--- a/docs/getting_started/echobot.rst
+++ b/docs/getting_started/echobot.rst
@@ -69,8 +69,8 @@ use ASCII. We can get Python to use UTF-8 as the default encoding by including:
 .. code-block:: python
 
     if sys.version_info < (3, 0):
-        reload(sys)
-        sys.setdefaultencoding('utf8')
+        from sleekxmpp.util.misc_ops import setdefaultencoding
+        setdefaultencoding('utf8')
 
 .. warning::
 

--- a/examples/adhoc_provider.py
+++ b/examples/adhoc_provider.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/adhoc_user.py
+++ b/examples/adhoc_user.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/admin_commands.py
+++ b/examples/admin_commands.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/custom_stanzas/custom_stanza_provider.py
+++ b/examples/custom_stanzas/custom_stanza_provider.py
@@ -28,8 +28,8 @@ from stanza import Action
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 
@@ -56,8 +56,8 @@ class ActionBot(sleekxmpp.ClientXMPP):
             StanzaPath('iq@type=set/action'),
             self._handle_action))
 
-        self.add_event_handler('custom_action', 
-                self._handle_action_event, 
+        self.add_event_handler('custom_action',
+                self._handle_action_event,
                 threaded=True)
 
         register_stanza_plugin(Iq, Action)

--- a/examples/custom_stanzas/custom_stanza_user.py
+++ b/examples/custom_stanzas/custom_stanza_user.py
@@ -26,8 +26,8 @@ from stanza import Action
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/disco_browser.py
+++ b/examples/disco_browser.py
@@ -23,8 +23,8 @@ from sleekxmpp.exceptions import IqError, IqTimeout
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/download_avatars.py
+++ b/examples/download_avatars.py
@@ -24,8 +24,8 @@ from sleekxmpp.exceptions import XMPPError
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/echo_client.py
+++ b/examples/echo_client.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/echo_component.py
+++ b/examples/echo_component.py
@@ -22,8 +22,8 @@ from sleekxmpp.componentxmpp import ComponentXMPP
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/gtalk_custom_domain.py
+++ b/examples/gtalk_custom_domain.py
@@ -25,8 +25,8 @@ from sleekxmpp.xmlstream import cert
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/ibb_transfer/ibb_receiver.py
+++ b/examples/ibb_transfer/ibb_receiver.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/ibb_transfer/ibb_sender.py
+++ b/examples/ibb_transfer/ibb_sender.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/muc.py
+++ b/examples/muc.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/ping.py
+++ b/examples/ping.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/proxy_echo_client.py
+++ b/examples/proxy_echo_client.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/pubsub_client.py
+++ b/examples/pubsub_client.py
@@ -12,8 +12,8 @@ from sleekxmpp.xmlstream import ET, tostring
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/pubsub_events.py
+++ b/examples/pubsub_events.py
@@ -14,8 +14,8 @@ from sleekxmpp.xmlstream.handler import Callback
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/register_account.py
+++ b/examples/register_account.py
@@ -22,8 +22,8 @@ from sleekxmpp.exceptions import IqError, IqTimeout
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/roster_browser.py
+++ b/examples/roster_browser.py
@@ -24,8 +24,8 @@ from sleekxmpp.exceptions import IqError, IqTimeout
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/send_client.py
+++ b/examples/send_client.py
@@ -21,8 +21,8 @@ import sleekxmpp
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/set_avatar.py
+++ b/examples/set_avatar.py
@@ -26,8 +26,8 @@ from sleekxmpp.exceptions import XMPPError
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/examples/thirdparty_auth.py
+++ b/examples/thirdparty_auth.py
@@ -29,8 +29,8 @@ from sleekxmpp.xmlstream import JID
 # throughout SleekXMPP, we will set the default encoding
 # ourselves to UTF-8.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 else:
     raw_input = input
 

--- a/sleekxmpp/basexmpp.py
+++ b/sleekxmpp/basexmpp.py
@@ -43,8 +43,8 @@ log = logging.getLogger(__name__)
 # In order to make sure that Unicode is handled properly
 # in Python 2.x, reset the default encoding.
 if sys.version_info < (3, 0):
-    reload(sys)
-    sys.setdefaultencoding('utf8')
+    from sleekxmpp.util.misc_ops import setdefaultencoding
+    setdefaultencoding('utf8')
 
 
 class BaseXMPP(XMLStream):

--- a/sleekxmpp/util/misc_ops.py
+++ b/sleekxmpp/util/misc_ops.py
@@ -125,3 +125,27 @@ def hashes():
         t += ['MD2']
     hashes = ['SHA-' + h[3:] for h in dir(hashlib) if h.startswith('sha')]
     return t + hashes
+
+def setdefaultencoding(encoding):
+    """
+    Set the current default string encoding used by the Unicode implementation.
+
+    Actually calls sys.setdefaultencoding under the hood - see the docs for that
+    for more details.  This method exists only as a way to call find/call it
+    even after it has been 'deleted' when the site module is executed.
+
+    :param string encoding: An encoding name, compatible with sys.setdefaultencoding
+    """
+    func = getattr(sys, 'setdefaultencoding', None)
+    if func is None:
+        import gc
+        import types
+        for obj in gc.get_objects():
+            if (isinstance(obj, types.BuiltinFunctionType)
+                    and obj.__name__ == 'setdefaultencoding'):
+                func = obj
+                break
+        if func is None:
+            raise RuntimeError("Could not find setdefaultencoding")
+        sys.setdefaultencoding = func
+    return func(encoding)


### PR DESCRIPTION
This commit adds sleekxmpp.utils.misc_ops.setdefaultencoding, which allows setting of default encoding WITHOUT needing a reload(sys)

reload(sys) was causing problems for us in some applications, because it will reset sys.stdout, excepthook, displayhook, etc.

The new setdefaultencoding find the "original" sys.setdefaultencoding by searching through the list of objects kept by the garbage collector.  The function is never actually garbage collected, so it works... presumably because it's a builtin function?
