### PR TITLE
Pull request gevent check

### DIFF
--- a/sleekxmpp/util/__init__.py
+++ b/sleekxmpp/util/__init__.py
@@ -18,7 +18,18 @@ from sleekxmpp.util.misc_ops import bytes, unicode, hashes, hash, \
 # Standardize import of Queue class:
 
 import sys
-if 'gevent' in sys.modules:
+
+def _gevent_threads_enabled():
+    if not 'gevent' in sys.modules:
+        return False
+    try:
+        from gevent import thread as green_thread
+        thread = __import__('thread')
+        return thread.LockType is green_thread.LockType
+    except ImportError:
+        return False
+
+if _gevent_threads_enabled():
     import gevent.queue as queue
     Queue = queue.JoinableQueue
 else:

--- a/testall.py
+++ b/testall.py
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 
-import os
 import sys
+if len(sys.argv)>1 and sys.argv[1].lower() == 'gevent':
+    from gevent import monkey
+    monkey.patch_all()
+
+import os
 import logging
 import unittest
 import distutils.core
@@ -57,7 +61,7 @@ class TestCommand(distutils.core.Command):
 
 if __name__ == '__main__':
     result = run_tests()
-    print("<tests %s ran='%s' errors='%s' fails='%s' success='%s' />" % (
+    print("<tests %s ran='%s' errors='%s' fails='%s' success='%s' gevent_enabled=%s/>" % (
         "xmlns='http//andyet.net/protocol/tests'",
         result.testsRun, len(result.errors),
-        len(result.failures), result.wasSuccessful()))
+        len(result.failures), result.wasSuccessful(),'gevent' in sys.modules))


### PR DESCRIPTION
Sometimes gevent has been loaded as module but monkey patch has not been performed. (f.e: Pymongo is doing it)

With the patch I propose to check if system thread module has been "monkey patched" with gevent and then do  the right import of Queue.

Also I have added a parameter on **testall.py** to check the testsuite with gevent enabled/disabled.

Time elapsed doing the **test suite** has been improved a lot (at my desktop from 30 to 10 seconds)
