### PR TITLE
Don't use internally deprecated methods

### DIFF
--- a/docs/create_plugin.rst
+++ b/docs/create_plugin.rst
@@ -222,7 +222,7 @@ handler function to process registration requests.
         self.description = "In-Band Registration"
         self.xep = "0077"
 
-        self.xmpp.registerHandler(
+        self.xmpp.register_handler(
           Callback('In-Band Registration',
             MatchXPath('{%s}iq/{jabber:iq:register}query' % self.xmpp.default_ns),
             self.__handleRegistration))
@@ -601,7 +601,7 @@ with some additional registration fields implemented.
             self.form_instructions = ""
             self.backend = UserStore()
 
-            self.xmpp.registerHandler(
+            self.xmpp.register_handler(
                 Callback('In-Band Registration',
                          MatchXPath('{%s}iq/{jabber:iq:register}query' % self.xmpp.default_ns),
                          self.__handleRegistration))

--- a/examples/custom_stanzas/custom_stanza_provider.py
+++ b/examples/custom_stanzas/custom_stanza_provider.py
@@ -51,7 +51,7 @@ class ActionBot(sleekxmpp.ClientXMPP):
         # our roster.
         self.add_event_handler("session_start", self.start)
 
-        self.registerHandler(
+        self.register_handler(
           Callback('Some custom iq',
             StanzaPath('iq@type=set/action'),
             self._handle_action))

--- a/sleekxmpp/plugins/xep_0009/rpc.py
+++ b/sleekxmpp/plugins/xep_0009/rpc.py
@@ -32,15 +32,15 @@ class XEP_0009(BasePlugin):
         register_stanza_plugin(RPCQuery, MethodCall)
         register_stanza_plugin(RPCQuery, MethodResponse)
 
-        self.xmpp.registerHandler(
+        self.xmpp.register_handler(
             Callback('RPC Call', MatchXPath('{%s}iq/{%s}query/{%s}methodCall' % (self.xmpp.default_ns, RPCQuery.namespace, RPCQuery.namespace)),
             self._handle_method_call)
         )
-        self.xmpp.registerHandler(
+        self.xmpp.register_handler(
             Callback('RPC Call', MatchXPath('{%s}iq/{%s}query/{%s}methodResponse' % (self.xmpp.default_ns, RPCQuery.namespace, RPCQuery.namespace)),
             self._handle_method_response)
         )
-        self.xmpp.registerHandler(
+        self.xmpp.register_handler(
             Callback('RPC Call', MatchXPath('{%s}iq/{%s}error' % (self.xmpp.default_ns, self.xmpp.default_ns)),
             self._handle_error)
         )

--- a/sleekxmpp/plugins/xep_0045.py
+++ b/sleekxmpp/plugins/xep_0045.py
@@ -125,11 +125,11 @@ class XEP_0045(BasePlugin):
         self.xep = '0045'
         # load MUC support in presence stanzas
         register_stanza_plugin(Presence, MUCPresence)
-        self.xmpp.registerHandler(Callback('MUCPresence', MatchXMLMask("<presence xmlns='%s' />" % self.xmpp.default_ns), self.handle_groupchat_presence))
-        self.xmpp.registerHandler(Callback('MUCMessage', MatchXMLMask("<message xmlns='%s' type='groupchat'><body/></message>" % self.xmpp.default_ns), self.handle_groupchat_message))
-        self.xmpp.registerHandler(Callback('MUCSubject', MatchXMLMask("<message xmlns='%s' type='groupchat'><subject/></message>" % self.xmpp.default_ns), self.handle_groupchat_subject))
-        self.xmpp.registerHandler(Callback('MUCConfig', MatchXMLMask("<message xmlns='%s' type='groupchat'><x xmlns='http://jabber.org/protocol/muc#user'><status/></x></message>" % self.xmpp.default_ns), self.handle_config_change))
-        self.xmpp.registerHandler(Callback('MUCInvite', MatchXPath("{%s}message/{%s}x/{%s}invite" % (
+        self.xmpp.register_handler(Callback('MUCPresence', MatchXMLMask("<presence xmlns='%s' />" % self.xmpp.default_ns), self.handle_groupchat_presence))
+        self.xmpp.register_handler(Callback('MUCMessage', MatchXMLMask("<message xmlns='%s' type='groupchat'><body/></message>" % self.xmpp.default_ns), self.handle_groupchat_message))
+        self.xmpp.register_handler(Callback('MUCSubject', MatchXMLMask("<message xmlns='%s' type='groupchat'><subject/></message>" % self.xmpp.default_ns), self.handle_groupchat_subject))
+        self.xmpp.register_handler(Callback('MUCConfig', MatchXMLMask("<message xmlns='%s' type='groupchat'><x xmlns='http://jabber.org/protocol/muc#user'><status/></x></message>" % self.xmpp.default_ns), self.handle_config_change))
+        self.xmpp.register_handler(Callback('MUCInvite', MatchXPath("{%s}message/{%s}x/{%s}invite" % (
             self.xmpp.default_ns,
             'http://jabber.org/protocol/muc#user',
             'http://jabber.org/protocol/muc#user')), self.handle_groupchat_invite))

--- a/sleekxmpp/plugins/xep_0202/time.py
+++ b/sleekxmpp/plugins/xep_0202/time.py
@@ -48,7 +48,7 @@ class XEP_0202(BasePlugin):
 
             self.local_time = default_local_time
 
-        self.xmpp.registerHandler(
+        self.xmpp.register_handler(
             Callback('Entity Time',
                  StanzaPath('iq/entity_time'),
                  self._handle_time_request))

--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -1015,8 +1015,8 @@ class XMLStream(object):
         # and handler classes here.
 
         if name is None:
-            name = 'add_handler_%s' % self.getNewId()
-        self.registerHandler(XMLCallback(name, MatchXMLMask(mask), pointer,
+            name = 'add_handler_%s' % self.new_id()
+        self.register_handler(XMLCallback(name, MatchXMLMask(mask), pointer,
                                          once=disposable, instream=instream))
 
     def register_handler(self, handler, before=None, after=None):

--- a/tests/test_stream_handlers.py
+++ b/tests/test_stream_handlers.py
@@ -21,7 +21,7 @@ class TestHandlers(SleekTest):
         """Test using stream callback handlers."""
 
         def callback_handler(stanza):
-            self.xmpp.sendRaw("""
+            self.xmpp.send_raw("""
               <message>
                 <body>Success!</body>
               </message>
@@ -31,7 +31,7 @@ class TestHandlers(SleekTest):
                             MatchXPath('{test}tester'),
                             callback_handler)
 
-        self.xmpp.registerHandler(callback)
+        self.xmpp.register_handler(callback)
 
         self.recv("""<tester xmlns="test" />""")
 
@@ -49,7 +49,7 @@ class TestHandlers(SleekTest):
             iq['query'] = 'test'
             reply = iq.send(block=True)
             if reply:
-                self.xmpp.sendRaw("""
+                self.xmpp.send_raw("""
                   <message>
                     <body>Successful: %s</body>
                   </message>
@@ -112,7 +112,7 @@ class TestHandlers(SleekTest):
         time.sleep(0.1)
 
         # Check that the waiter is no longer registered
-        waiter_exists = self.xmpp.removeHandler('IqWait_test2')
+        waiter_exists = self.xmpp.remove_handler('IqWait_test2')
 
         self.failUnless(waiter_exists == False,
             "Waiter handler was not removed.")


### PR DESCRIPTION
During some code-review I've found some places where library used deprecated methods.

Some grep'ping helped me to fix that.
