### PR TITLE
Correct argument order by using keyword for keepalive.

### DIFF
--- a/sleekxmpp/plugins/xep_0199/ping.py
+++ b/sleekxmpp/plugins/xep_0199/ping.py
@@ -106,7 +106,7 @@ class XEP_0199(BasePlugin):
     def _keepalive(self, event=None):
         log.debug("Keepalive ping...")
         try:
-            rtt = self.ping(self.xmpp.boundjid.host, self.timeout)
+            rtt = self.ping(self.xmpp.boundjid.host, timeout=self.timeout)
         except IqTimeout:
             log.debug("Did not recieve ping back in time." + \
                       "Requesting Reconnect.")


### PR DESCRIPTION
Fixes a minor bug which causes the automatic pinging (from XEP_0199.enable_keepalive) to fail with a harmless error. Nothing bad happens, except we aren't actually pinging the other side.

Commit 3423589b changed the ordering of the arguments such that ifrom is the second argument in ping().

However keepalive is still passing timeout as the second argument. This causes all pings to fail with the following exception:

```
Traceback (most recent call last):
File "build/bdist.linux-x86_64/egg/sleekxmpp/plugins/xep_0199/ping.py", line 109, in _keepalive
  rtt = self.ping(self.xmpp.boundjid.host, self.timeout)
File "build/bdist.linux-x86_64/egg/sleekxmpp/plugins/xep_0199/ping.py", line 174, in ping
  self.send_ping(jid, ifrom=ifrom, timeout=timeout)
File "build/bdist.linux-x86_64/egg/sleekxmpp/plugins/xep_0199/ping.py", line 146, in send_ping
  return iq.send(block=block, timeout=timeout, callback=callback)
File "build/bdist.linux-x86_64/egg/sleekxmpp/stanza/iq.py", line 227, in send
  StanzaBase.send(self, now=now)
File "build/bdist.linux-x86_64/egg/sleekxmpp/xmlstream/stanzabase.py", line 1595, in send
  self.stream.send(self, now=now)
File "build/bdist.linux-x86_64/egg/sleekxmpp/xmlstream/xmlstream.py", line 1209, in send
  top_level=True)
File "build/bdist.linux-x86_64/egg/sleekxmpp/xmlstream/tostring.py", line 89, in tostring
  value = escape(value, use_cdata)
File "build/bdist.linux-x86_64/egg/sleekxmpp/xmlstream/tostring.py", line 149, in escape
  text = unicode(text, 'utf-8', 'ignore')
TypeError: coercing to Unicode: need string or buffer, int found
```
