### PR TITLE
Fix in tzoffset and _get_fixed_offset_tz

### DIFF
--- a/sleekxmpp/thirdparty/mini_dateutil.py
+++ b/sleekxmpp/thirdparty/mini_dateutil.py
@@ -108,7 +108,7 @@ except:
 
         def __init__(self, name, offset):
             self._name = name
-            self._offset = datetime.timedelta(seconds=offset)
+            self._offset = datetime.timedelta(minutes=offset)
 
         def utcoffset(self, dt):
             return self._offset
@@ -154,7 +154,7 @@ except:
                 absoff = offsetmins
 
             name = "UTC%s%02d:%02d" % (sign, int(absoff / 60), absoff % 60)
-            inst = tzoffset(offsetmins, name)
+            inst = tzoffset(name,offsetmins)
             _fixed_offset_tzs[offsetmins] = inst
 
         return _fixed_offset_tzs[offsetmins]


### PR DESCRIPTION
The tzoffset object is constructed with offset in minutes not in
seconds so to timedelta offset must be passed as minutes not seconds. In the _get_fixed_offset_tz the tzoffset was called with wrong parameter order.
