### PR TITLE
.stripped() would result in error

### DIFF
--- a/sleekxmpp/plugins/xep_0027/gpg.py
+++ b/sleekxmpp/plugins/xep_0027/gpg.py
@@ -24,7 +24,7 @@ def _extract_data(data, kind):
         if not begin_headers and 'BEGIN PGP %s' % kind in line:
             begin_headers = True
             continue
-        if begin_headers and line.stripped() == '':
+        if begin_headers and line.strip() == '':
             begin_data = True
             continue
         if 'END PGP %s' % kind in line:


### PR DESCRIPTION
If .stripped() was hit, then a traceback would come back saying "str does not have attribute stripped".

I haven't used Python previous of 2.7.x so I'm not sure if it was called stripped() at some point, but strip() is the more relevant version of the method.
