### PR TITLE
Properly set itemID for XEP-0084 metadata

### DIFF
--- a/sleekxmpp/plugins/xep_0084/avatar.py
+++ b/sleekxmpp/plugins/xep_0084/avatar.py
@@ -82,6 +82,7 @@ class XEP_0084(BasePlugin):
                 metadata.add_pointer(pointer)
 
         return self.xmpp['xep_0163'].publish(metadata,
+                id=info['id'],
                 ifrom=ifrom,
                 block=block,
                 callback=callback,


### PR DESCRIPTION
XEP-0084 says:
«Whenever the publisher wishes to change its current avatar, it MUST update the metadata node. As with the data node, the publisher MUST ensure that the value of the pubsub ItemID is a SHA-1 hash of the data for the "image/png" content-type[…]»
