### PR TITLE
Skip EINTR errors on raw sockets

### DIFF
--- a/sleekxmpp/xmlstream/filesocket.py
+++ b/sleekxmpp/xmlstream/filesocket.py
@@ -13,6 +13,7 @@
 """
 
 from socket import _fileobject
+import errno
 import socket
 
 
@@ -29,7 +30,13 @@ class FileSocket(_fileobject):
         """Read data from the socket as if it were a file."""
         if self._sock is None:
             return None
-        data = self._sock.recv(size)
+        while True:
+            try:
+                data = self._sock.recv(size)
+                break
+            except socket.error as serr:
+                if serr.errno != errno.EINTR:
+                    raise
         if data is not None:
             return data
 

--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -1294,6 +1294,9 @@ class XMLStream(object):
                         try:
                             sent += self.socket.send(data[sent:])
                             count += 1
+                        except Socket.error as serr:
+                            if serr.errno != errno.EINTR:
+                                raise
                         except ssl.SSLError as serr:
                             if tries >= self.ssl_retry_max:
                                 log.debug('SSL error: max retries reached')
@@ -1715,6 +1718,9 @@ class XMLStream(object):
                             try:
                                 sent += self.socket.send(enc_data[sent:])
                                 count += 1
+                            except Socket.error as serr:
+                                if serr.errno != errno.EINTR:
+                                    raise
                             except ssl.SSLError as serr:
                                 if tries >= self.ssl_retry_max:
                                     log.debug('SSL error: max retries reached')


### PR DESCRIPTION
When system signal arrives to application locked on syscall - this syscall ends with EINTR error. Python convert such errors to different exceptions. Correct workaround - just run syscall again.

SSL sockets handles EINTR internally and application doesn't receive any exceptions. Raw sockets throws, and Sleek doesn't handle it correctly - it breaks current connection.

I've fixed at the most obvious and frequently executed syscalls.
