### PR TITLE
Speedup main threads loops

### DIFF
--- a/sleekxmpp/xmlstream/scheduler.py
+++ b/sleekxmpp/xmlstream/scheduler.py
@@ -157,16 +157,15 @@ class Scheduler(object):
                     if wait <= 0.0:
                         newtask = self.addq.get(False)
                     else:
-                        if wait > 3.0:
-                            wait = 3.0
                         newtask = None
-                        elapsed = 0
                         while self.run and \
                               not self.stop.is_set() and \
                               newtask is None and \
-                              elapsed < wait:
-                            newtask = self.addq.get(True, self.wait_timeout)
-                            elapsed += self.wait_timeout
+                              wait > 0:
+                            try:
+                                newtask = self.addq.get(True, min(wait, self.wait_timeout))
+                            except QueueEmpty:          # Nothing to add, nothing to do. Check run flags and continue waiting.
+                                wait -= self.wait_timeout
                 except QueueEmpty:                      # Time to run some tasks, and no new tasks to add.
                     self.schedule_lock.acquire()
                     # select only those tasks which are to be executed now

--- a/sleekxmpp/xmlstream/scheduler.py
+++ b/sleekxmpp/xmlstream/scheduler.py
@@ -20,6 +20,11 @@ import itertools
 from sleekxmpp.util import Queue, QueueEmpty
 
 
+#: The time in seconds to wait for events from the event queue, and also the
+#: time between checks for the process stop signal.
+WAIT_TIMEOUT = 1.0
+
+
 log = logging.getLogger(__name__)
 
 
@@ -120,6 +125,10 @@ class Scheduler(object):
         #: Lock for accessing the task queue.
         self.schedule_lock = threading.RLock()
 
+        #: The time in seconds to wait for events from the event queue,
+        #: and also the time between checks for the process stop signal.
+        self.wait_timeout = WAIT_TIMEOUT
+
     def process(self, threaded=True, daemon=False):
         """Begin accepting and processing scheduled tasks.
 
@@ -143,7 +152,7 @@ class Scheduler(object):
                 if self.schedule:
                     wait = self.schedule[0].next - time.time()
                 else:
-                    wait = 0.1
+                    wait = self.wait_timeout
                 try:
                     if wait <= 0.0:
                         newtask = self.addq.get(False)
@@ -156,8 +165,8 @@ class Scheduler(object):
                               not self.stop.is_set() and \
                               newtask is None and \
                               elapsed < wait:
-                            newtask = self.addq.get(True, 0.1)
-                            elapsed += 0.1
+                            newtask = self.addq.get(True, self.wait_timeout)
+                            elapsed += self.wait_timeout
                 except QueueEmpty:                      # Time to run some tasks, and no new tasks to add.
                     self.schedule_lock.acquire()
                     # select only those tasks which are to be executed now

--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -49,7 +49,7 @@ RESPONSE_TIMEOUT = 30
 
 #: The time in seconds to wait for events from the event queue, and also the
 #: time between checks for the process stop signal.
-WAIT_TIMEOUT = 0.1
+WAIT_TIMEOUT = 1.0
 
 #: The number of threads to use to handle XML stream events. This is not the
 #: same as the number of custom event handling threads.
@@ -1629,8 +1629,7 @@ class XMLStream(object):
         try:
             while not self.stop.is_set():
                 try:
-                    wait = self.wait_timeout
-                    event = self.event_queue.get(True, timeout=wait)
+                    event = self.event_queue.get(True, timeout=self.wait_timeout)
                 except QueueEmpty:
                     event = None
                 if event is None:
@@ -1693,13 +1692,13 @@ class XMLStream(object):
             while not self.stop.is_set():
                 while not self.stop.is_set() and \
                       not self.session_started_event.is_set():
-                    self.session_started_event.wait(timeout=0.1)
+                    self.session_started_event.wait(timeout=0.1)                            # Wait for session start
                 if self.__failed_send_stanza is not None:
                     data = self.__failed_send_stanza
                     self.__failed_send_stanza = None
                 else:
                     try:
-                        data = self.send_queue.get(True, 1)
+                        data = self.send_queue.get(True, timeout=self.wait_timeout)         # Wait for data to send
                     except QueueEmpty:
                         continue
                 log.debug("SEND: %s", data)


### PR DESCRIPTION
I'm using this library in application which runs lots of weak loaded xmpp connections. I've expected that it shouldn't consume lots of resources, but this is not true.

I've found that all 4 main threads almost never sleeps and always loops over and over. If I correctly understand, they all breaks waiting (net IO or get from Queue) to check stop Condition. 3 loops checks if every 100 ms, and one - every 1 second. In result all threads can be stopped in 0..1 second (after latest one). I think this is reasonable time to stop. But other threads checks stop flags faster, and they have no reason to do that.

I've made a patch to reduce useless CPU consuming:
- All threads use same config variable as check rate (WAIT_TIMEOUT).
- I've increase timeouts in some threads, but it doesn't affect total time to stop.
- I've replaced magic numbers by named properties in main loops.
- There was no reason in scheduler to mandatory break loop every 3 seconds. Now it goes through small loop until time of next event.
- There was a bug in loop, it couldn't loop over small loop more than one time because of QueueEmpty exception.

I've benchmarked upstream and patched version on idle mode. After 2 hours of work patched version consumed 2.3 times less CPU.

I'm not sure that I totally understand entire library, maybe you had some reasons to implement it that way. I want to know if I'm doing something wrong.

If this patch is OK, maybe I'll continue some optimization work later.
