### PR TITLE
Blocking queue get

### DIFF
--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -462,10 +462,10 @@ class XMLStream(object):
                     time.sleep(0.1)
                     elapsed += 0.1
             except KeyboardInterrupt:
-                self.stop.set()
+                self.set_stop()
                 return False
             except SystemExit:
-                self.stop.set()
+                self.set_stop()
                 return False
 
         if self.default_domain:
@@ -707,7 +707,7 @@ class XMLStream(object):
             self.stream_end_event.set()
 
         if not self.auto_reconnect:
-            self.stop.set()
+            self.set_stop()
             if self._disconnect_wait_for_threads:
                 self._wait_for_threads()
 
@@ -724,7 +724,7 @@ class XMLStream(object):
 
     def abort(self):
         self.session_started_event.clear()
-        self.stop.set()
+        self.set_stop()
         if self._disconnect_wait_for_threads:
             self._wait_for_threads()
         try:
@@ -1360,6 +1360,13 @@ class XMLStream(object):
             if self.__thread_count == 0:
                 self.__thread_cond.notify()
 
+    def set_stop(self):
+        self.stop.set()
+
+        # Unlock queues
+        self.event_queue.put(None)
+        self.send_queue.put(None)
+
     def _wait_for_threads(self):
         with self.__thread_cond:
             if self.__thread_count != 0:
@@ -1632,10 +1639,7 @@ class XMLStream(object):
         log.debug("Loading event runner")
         try:
             while not self.stop.is_set():
-                try:
-                    event = self.event_queue.get(True, timeout=self.wait_timeout)
-                except QueueEmpty:
-                    event = None
+                event = self.event_queue.get()
                 if event is None:
                     continue
 
@@ -1701,9 +1705,8 @@ class XMLStream(object):
                     data = self.__failed_send_stanza
                     self.__failed_send_stanza = None
                 else:
-                    try:
-                        data = self.send_queue.get(True, timeout=self.wait_timeout)         # Wait for data to send
-                    except QueueEmpty:
+                    data = self.send_queue.get()                                            # Wait for data to send
+                    if data is None:
                         continue
                 log.debug("SEND: %s", data)
                 enc_data = data.encode('utf-8')


### PR DESCRIPTION
I'm continuing (#244) to optimize main loops to reduce CPU usage in idle mode.

When we are using non-blocking Queue.get with timeout, underlying Condition doesn't lock for all timeout. It starts to lock and release frequently.

I've replaced non-blocking Queue.get to blocking one. Previously we've used timeout to break thread loop cycle on stopping event. Now I'm breaking loop by putting `None` into queues. Queue.get unblocks and thread react on stop flag.

After this we have only Scheduler loop with non-blocking get. But it have to be non-blocking with timeout for running tasks. Possible next step — not to split timeout to `wait_timeout` portions should decrease cpu usage too, but not so notably. I've left it as is right now.

I've benchmarked both of this improvements (#244 and current). I've started 3 `echo_client`s with original version (baf9aaf26c80c87e770cdf35b1fa4fe231663246), after #244 and after both of them.

9 hours of running with no incoming messages gave me this `ps aux`:

```
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
user      1428  1.4  0.4 285720 14548 pts/0    Sl   01:10   6:56 python ./echo_client.py
user      1458  0.5  0.4 285736 14564 pts/0    Sl   01:10   2:45 python ./echo_client.py
user      1489  0.2  0.4 285736 14560 pts/0    Sl   01:10   0:59 python ./echo_client.py
```
