### PR TITLE
Caught OSError when querying AAAA records.

### DIFF
--- a/sleekxmpp/xmlstream/resolver.py
+++ b/sleekxmpp/xmlstream/resolver.py
@@ -206,11 +206,7 @@ def get_AAAA(host, resolver=None):
             recs = socket.getaddrinfo(host, None, socket.AF_INET6,
                                                   socket.SOCK_STREAM)
             return [rec[4][0] for rec in recs]
-        except socket.gaierror:
-            log.debug("DNS: Error retreiving AAAA address " + \
-                      "info for %s." % host)
-            return []
-        except OSError:
+        except (OSError, socket.gaierror):
             log.debug("DNS: Error retreiving AAAA address " + \
                       "info for %s." % host)
             return []

--- a/sleekxmpp/xmlstream/resolver.py
+++ b/sleekxmpp/xmlstream/resolver.py
@@ -210,6 +210,10 @@ def get_AAAA(host, resolver=None):
             log.debug("DNS: Error retreiving AAAA address " + \
                       "info for %s." % host)
             return []
+        except OSError:
+            log.debug("DNS: Error retreiving AAAA address " + \
+                      "info for %s." % host)
+            return []
 
     # Using dnspython:
     try:


### PR DESCRIPTION
On my machine, I have an IPv6 address, but it is only a local address (starts with "fe"). I believe that this was causing SleekXMPP to assume I have a real IPv6 connection and then trying to use it. 

I would receive this traceback:

```
Traceback (most recent call last):
  File "./procbot.py", line 266, in <module>
    adp.run()
  File "./procbot.py", line 71, in run
    if client.connect((self.config['server'], self.config['port'])):
  File "/home/jake/Code/SleekXMPP/sleekxmpp/clientxmpp.py", line 162, in connect
    reattempt=reattempt)
  File "/home/jake/Code/SleekXMPP/sleekxmpp/xmlstream/xmlstream.py", line 438, in connect
    args=(reattempt,))
  File "/home/jake/Code/SleekXMPP/sleekxmpp/thirdparty/statemachine.py", line 69, in transition
    func=func, args=args, kwargs=kwargs)
  File "/home/jake/Code/SleekXMPP/sleekxmpp/thirdparty/statemachine.py", line 110, in transition_any
    return_val = func(*args,**kwargs) if func is not None else True
  File "/home/jake/Code/SleekXMPP/sleekxmpp/xmlstream/xmlstream.py", line 474, in _connect
    self.address[1])
  File "/home/jake/Code/SleekXMPP/sleekxmpp/xmlstream/xmlstream.py", line 1084, in pick_dns_answer
    return next(self.dns_answers)
  File "/home/jake/Code/SleekXMPP/sleekxmpp/xmlstream/resolver.py", line 134, in resolve
    for address in get_AAAA(host, resolver=resolver):
  File "/home/jake/Code/SleekXMPP/sleekxmpp/xmlstream/resolver.py", line 207, in get_AAAA
    socket.SOCK_STREAM)
OSError: [Errno 0] Error
```

Adding an `except` for OSError at that point and returning `[]` seems to have fixed it. I admit that I do not know the implications of catching that error at that point, but it seems to work for me. Let me know if you have a better way.
