### PR TITLE
performance in jid : optimization

### DIFF
--- a/sleekxmpp/jid.py
+++ b/sleekxmpp/jid.py
@@ -506,50 +506,100 @@ class JID(object):
         """
         self._jid = JID(data)._jid
 
-    # pylint: disable=R0911
-    def __getattr__(self, name):
-        """Retrieve the given JID component.
+    @property
+    def resource(self):
+        return self._jid[2] or ''
 
-        :param name: one of: user, server, domain, resource,
-                     full, or bare.
-        """
-        if name == 'resource':
-            return self._jid[2] or ''
-        elif name in ('user', 'username', 'local', 'node'):
-            return self._jid[0] or ''
-        elif name in ('server', 'domain', 'host'):
-            return self._jid[1] or ''
-        elif name in ('full', 'jid'):
-            return _format_jid(*self._jid)
-        elif name == 'bare':
-            return _format_jid(self._jid[0], self._jid[1])
-        elif name == '_jid':
-            return getattr(super(JID, self), '_jid')
-        else:
-            return None
+    @property
+    def user(self):
+        return self._jid[0] or ''
 
-    # pylint: disable=W0212
-    def __setattr__(self, name, value):
-        """Update the given JID component.
+    @property
+    def local(self):
+        return self._jid[0] or ''
 
-        :param name: one of: ``user``, ``username``, ``local``,
-                             ``node``, ``server``, ``domain``, ``host``,
-                             ``resource``, ``full``, ``jid``, or ``bare``.
-        :param value: The new string value of the JID component.
-        """
-        if name == '_jid':
-            super(JID, self).__setattr__('_jid', value)
-        elif name == 'resource':
-            self._jid = JID(self, resource=value)._jid
-        elif name in ('user', 'username', 'local', 'node'):
-            self._jid = JID(self, local=value)._jid
-        elif name in ('server', 'domain', 'host'):
-            self._jid = JID(self, domain=value)._jid
-        elif name in ('full', 'jid'):
-            self._jid = JID(value)._jid
-        elif name == 'bare':
-            parsed = JID(value)._jid
-            self._jid = (parsed[0], parsed[1], self._jid[2])
+    @property
+    def node(self):
+        return self._jid[0] or ''
+
+    @property
+    def username(self):
+        return self._jid[0] or ''
+
+    @property
+    def bare(self):
+        return _format_jid(self._jid[0], self._jid[1])
+
+    @property
+    def server(self):
+        return self._jid[1] or ''
+
+    @property
+    def domain(self):
+        return self._jid[1] or ''
+
+    @property
+    def host(self):
+        return self._jid[1] or ''
+
+    @property
+    def full(self):
+        return _format_jid(*self._jid)
+
+    @property
+    def jid(self):
+        return _format_jid(*self._jid)
+
+    @property
+    def bare(self):
+        return _format_jid(self._jid[0], self._jid[1])
+
+
+    @resource.setter
+    def resource(self, value):
+        self._jid = JID(self, resource=value)._jid
+
+    @user.setter
+    def user(self, value):
+        self._jid = JID(self, local=value)._jid
+
+    @username.setter
+    def username(self, value):
+        self._jid = JID(self, local=value)._jid
+
+    @local.setter
+    def local(self, value):
+        self._jid = JID(self, local=value)._jid
+
+    @node.setter
+    def node(self, value):
+        self._jid = JID(self, local=value)._jid
+
+    @server.setter
+    def server(self, value):
+        self._jid = JID(self, domain=value)._jid
+
+    @domain.setter
+    def domain(self, value):
+        self._jid = JID(self, domain=value)._jid
+
+    @host.setter
+    def host(self, value):
+        self._jid = JID(self, domain=value)._jid
+
+    @full.setter
+    def full(self, value):
+        self._jid = JID(value)._jid
+
+    @jid.setter
+    def jid(self, value):
+        self._jid = JID(value)._jid
+
+    @bare.setter
+    def bare(self, value):
+        parsed = JID(value)._jid
+        self._jid = (parsed[0], parsed[1], self._jid[2])
+
 
     def __str__(self):
         """Use the full JID as the string value."""


### PR DESCRIPTION
When profiling our app using sleek, we observed than it was spending a significant amout of time in jid.**setattr** and jid.**getattr** : (first number is the position ; the higher it is means more time spend in this method)

``` bash
grep -n jid old/stats_tsub.txt | head                                                                                                                                 
16:../sleekxmpp/jid.py.__getattr__:510  28054         0.278681  0.756717  0.000027
37:..ges/sleekxmpp/jid.py.__init__:434  15486         0.145309  3.125407  0.000202
41:../sleekxmpp/jid.py.__setattr__:532  31716         0.126427  0.210283  0.000007
95:.._jid.py.customer_name_from_jid:17  7616          0.055446  0.454063  0.000060
107:../sleekxmpp/jid.py._format_jid:319  9755          0.045821  0.084285  0.000009
109:../sleekxmpp/jid.py.__getattr__:510  4537          0.045728  0.123137  0.000027
140:..kxmpp/jid.py._validate_domain:176  744           0.033182  1.168661  0.001571
180:..ges/sleekxmpp/jid.py.__init__:434  2323          0.022359  0.593739  0.000256
190:../sleekxmpp/jid.py.__setattr__:532  4803          0.019310  0.032180  0.000007
256:..ges/sleekxmpp/jid.py.<lambda>:108  19002         0.011284  0.011284  0.000001
```

This implementation is much more verbose but faster, especially if you are dealing a lot with JIDs
on my box, ./testall.py now takes 45s. It takes 53s in the old implementation (about 15% faster). Our app spends much less time in jid.py :

``` bash
grep -n jid stats_tsub.txt | head                                                                                                                                           
50:..ges/sleekxmpp/jid.py.__init__:434  15891         0.102051  2.987120  0.000188
111:../sleekxmpp/jid.py._format_jid:319  9998          0.046407  0.085404  0.000009
112:.._jid.py.customer_name_from_jid:17  7847          0.046369  0.145187  0.000019
136:..kxmpp/jid.py._validate_domain:176  771           0.035105  1.212238  0.001572
206:..ges/sleekxmpp/jid.py.__init__:434  2424          0.016269  0.587972  0.000243
225:..ackages/sleekxmpp/jid.py.full:545  6212          0.013909  0.067937  0.000011
248:..kages/sleekxmpp/jid.py.domain:537  15313         0.012276  0.012276  0.000001
255:..ges/sleekxmpp/jid.py.<lambda>:108  19643         0.011927  0.011927  0.000001
280:..ko_full_jid.py.build_surfer_jid:5  1733          0.009301  0.039370  0.000023
304:.._jid.py.customer_name_from_jid:17  1477          0.007829  0.024348  0.000016
```
- all tests 
- all tests of my app ok
- all acceptance tests of my app ok

Thanks
