### PR TITLE
Don't resolve AAAA records if there is no dnspython nor IPv6 support

### DIFF
--- a/sleekxmpp/xmlstream/resolver.py
+++ b/sleekxmpp/xmlstream/resolver.py
@@ -202,6 +202,9 @@ def get_AAAA(host, resolver=None):
     # If not using dnspython, attempt lookup using the OS level
     # getaddrinfo() method.
     if resolver is None:
+        if not socket.has_ipv6:
+            log.debug("Unable to query %s for AAAA records: IPv6 is not supported", host)
+            return []
         try:
             recs = socket.getaddrinfo(host, None, socket.AF_INET6,
                                                   socket.SOCK_STREAM)


### PR DESCRIPTION
If system doesn't has IPv6 support or dnspython package, socket.getaddrinfo 
with AF_INET6 flag return weird IP info for requested host, making SleekXMPP 
crush with more weird error.
