### PR TITLE
Check delay field existence

### DIFF
--- a/sleekxmpp/plugins/xep_0091/stanza.py
+++ b/sleekxmpp/plugins/xep_0091/stanza.py
@@ -21,14 +21,15 @@ class LegacyDelay(ElementBase):
     interfaces = set(('from', 'stamp', 'text'))
 
     def get_from(self):
-        return JID(self._get_attr('from'))
+        from_ = self._get_attr('from')
+        return JID(from_) if from_ else None
 
     def set_from(self, value):
         self._set_attr('from', str(value))
 
     def get_stamp(self):
         timestamp = self._get_attr('stamp')
-        return xep_0082.parse('%sZ' % timestamp)
+        return xep_0082.parse('%sZ' % timestamp) if timestamp else None
 
     def set_stamp(self, value):
         if isinstance(value, dt.datetime):

--- a/sleekxmpp/plugins/xep_0203/stanza.py
+++ b/sleekxmpp/plugins/xep_0203/stanza.py
@@ -8,6 +8,7 @@
 
 import datetime as dt
 
+from sleekxmpp.jid import JID
 from sleekxmpp.xmlstream import ElementBase
 from sleekxmpp.plugins import xep_0082
 
@@ -20,14 +21,15 @@ class Delay(ElementBase):
     interfaces = set(('from', 'stamp', 'text'))
 
     def get_from(self):
-        return JID(self._get_attr('from'))
+        from_ = self._get_attr('from')
+        return JID(from_) if from_ else None
 
     def set_from(self, value):
         self._set_attr('from', str(value))
 
     def get_stamp(self):
         timestamp = self._get_attr('stamp')
-        return xep_0082.parse(timestamp)
+        return xep_0082.parse(timestamp) if timestamp else None
 
     def set_stamp(self, value):
         if isinstance(value, dt.datetime):


### PR DESCRIPTION
Now there is no way to check if we have &lt;delay&gt; stanza inside message.

`msg['delay']` is always object, `bool(msg['delay'])` always `True`.
`msg['delay'].get_from()` is object and True.
`msg['delay'].get_text()` depends on server.
`msg['delay'].get_stamp()` fails on non-delayed messages with `ValueError`.

I'm returning None on non-delayed messages.

And import fix))
