### PR TITLE
Examples and thread counting

### DIFF
--- a/examples/echo_client.py
+++ b/examples/echo_client.py
@@ -151,7 +151,7 @@ if __name__ == '__main__':
         #
         # if xmpp.connect(('talk.google.com', 5222)):
         #     ...
-        xmpp.process(block=False)
+        xmpp.process(block=True)
         print("Done")
     else:
         print("Unable to connect.")

--- a/examples/ping.py
+++ b/examples/ping.py
@@ -37,7 +37,7 @@ class PingTest(sleekxmpp.ClientXMPP):
     def __init__(self, jid, password, pingjid):
         sleekxmpp.ClientXMPP.__init__(self, jid, password)
         if pingjid is None:
-            pingjid = self.jid
+            pingjid = self.boundjid.bare
         self.pingjid = pingjid
 
         # The session_start event will be triggered when

--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -1343,12 +1343,12 @@ class XMLStream(object):
         return True
 
     def _start_thread(self, name, target, track=True):
-        self.__active_threads.add(name)
         self.__thread[name] = threading.Thread(name=name, target=target)
         self.__thread[name].daemon = self._use_daemons
         self.__thread[name].start()
 
         if track:
+            self.__active_threads.add(name)
             with self.__thread_cond:
                 self.__thread_count += 1
 


### PR DESCRIPTION
Example used deprecated property.

`thread_count` when used in `.process(block=False)` counted 3 threads on start, 4 threads on stop. As result — confusing messages: `Stopped scheduler thread. -1 threads remain`.
