### PR TITLE
XEP-0065 Implementation Broken

### DIFF
--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -88,8 +88,9 @@ class XEP_0065(base_plugin):
 
         # Request that the proxy activate the session with the target.
         self.activate(proxy, sid, to, timeout=timeout)
-        self.xmpp.event('stream:%s:%s' % (sid, conn.peer_jid), conn)
-        return self.get_socket(sid)
+        socket = self.get_socket(sid)
+        self.xmpp.event('stream:%s:%s' % (sid, to), socket)
+        return socket
 
     def request_stream(self, to, sid=None, ifrom=None, block=True, timeout=None, callback=None):
         if sid is None:


### PR DESCRIPTION
There are two minor bugs in plugins/xep_0065/proxy.py:
1. Line 91 references an undefined variable "conn" (causing a NameError).
2. "deactivate" tries to remove the sid from "self._sessions" though this is already handled by "sock.close()" (causing a KeyError)
