### PR TITLE
Fix for XEP-0030 'Result-set for all items'

### DIFF
--- a/sleekxmpp/plugins/xep_0030/static.py
+++ b/sleekxmpp/plugins/xep_0030/static.py
@@ -235,11 +235,14 @@ class StaticDisco(object):
         The data parameter is not used.
         """
         with self.lock:
-            if not self.node_exists(jid, node):
-                if not node:
-                    return DiscoItems()
-                else:
-                    raise XMPPError(condition='item-not-found')
+            if not node:  # Empty node, get all items
+                ret = DiscoItems()
+                for node in self.nodes.values():
+                    for jid, node, name in node['items'].get_items():
+                        ret.add_item(jid, node, name)
+                return ret
+            elif not self.node_exists(jid, node):
+                raise XMPPError(condition='item-not-found')
             else:
                 return self.get_node(jid, node)['items']
 


### PR DESCRIPTION
- As per http://xmpp.org/extensions/xep-0030.html#items Example 12, a
  disco#items request "... MUST return its list of publicly-available items,
  or return an error."
- This will have an extra 'node' attribute when requesting all items, but I
  don't think this will matter.
- After this patch, Pidgin will successfully see ad-hoc commands (as of 2.10.9)
