### PR TITLE
Fixes for the new XEP-0045 plugin

### DIFF
--- a/sleekxmpp/plugins/xep_0045/muc.py
+++ b/sleekxmpp/plugins/xep_0045/muc.py
@@ -214,13 +214,16 @@ class XEP_0045(BasePlugin):
             waiter = Queue()
 
         def on_resp(pres):
-            if pres['id'] == pid and pres['type'] == 'error':
-                self.xmpp.event('groupchat_join_failed', pres)
-                self.xmpp.event('muc::%s::joinfailed' % pres['from'].bare, pres)
-                if block:
-                    waiter.put(('failed', pres))
-            elif block:
-                waiter.put(('joined', pres))
+            if pres['id'] == pid:
+                if pres['type'] == 'error':
+                    self.xmpp.event('groupchat_join_failed', pres)
+                    self.xmpp.event('muc::%s::joinfailed' % pres['from'].bare, pres)
+                    if block:
+                        waiter.put(('failed', pres))
+                elif block:
+                    waiter.put(('joined', pres))
+            else:
+                return
 
             self.xmpp.del_event_handler('presence_error', on_resp)
             self.xmpp.del_event_handler('muc::%s::joined' % room, on_resp)

--- a/sleekxmpp/plugins/xep_0045/muc.py
+++ b/sleekxmpp/plugins/xep_0045/muc.py
@@ -115,7 +115,8 @@ class XEP_0045(BasePlugin):
             self._joined_rooms[jid] = set()
         self._joined_rooms[jid].add(node)
         self._nicks[(jid, node)] = data
-        self._roster[(jid, node)] = {}
+        if (jid, node) not in self._roster:
+            self._roster[(jid, node)] = {}
 
     def _del_joined_room(self, jid, node, ifrom, data):
         if jid in self._joined_rooms:

--- a/sleekxmpp/plugins/xep_0045/muc.py
+++ b/sleekxmpp/plugins/xep_0045/muc.py
@@ -56,6 +56,7 @@ class XEP_0045(BasePlugin):
     def plugin_init(self):
         register_stanza_plugin(Presence, stanza.MUC)
         register_stanza_plugin(Presence, stanza.MUCUser)
+        register_stanza_plugin(Message, stanza.MUCUser)
         register_stanza_plugin(Iq, stanza.MUCAdmin)
         register_stanza_plugin(Iq, stanza.MUCOwner)
         register_stanza_plugin(stanza.MUCAdmin, Form)
@@ -298,7 +299,7 @@ class XEP_0045(BasePlugin):
                     ifrom=mfrom)
         else:
             msg = self.xmpp.Message()
-            msg['to'] = to
+            msg['to'] = room
             msg['from'] = mfrom
             msg['muc']['invite']['to'] = jid
             msg['muc']['invite']['reason'] = reason

--- a/sleekxmpp/plugins/xep_0045/stanza.py
+++ b/sleekxmpp/plugins/xep_0045/stanza.py
@@ -123,8 +123,8 @@ class UserInvite(ElementBase):
     namespace = 'http://jabber.org/protocol/muc#user'
     plugin_attrib = 'invite'
     plugin_multi_attrib = 'invites'
-    interfaces = set(['to', 'from', 'reason'])
-    sub_interfaces = set(['reason'])
+    interfaces = set(['to', 'from', 'reason', 'password'])
+    sub_interfaces = set(['reason', 'password'])
 
     def get_to(self):
         return JID(self._get_attr('to'))


### PR DESCRIPTION
I've been using the `new_muc` branch for some time in a project of mine and I have some fixes to submit for it:
- Fixed a bug in the `_add_joined_room` method where it erases the roster for the room, clearing the client itself from the roster (ie the client is added to the roster then the roster is reset). Ashfire908@354789d
- Various typos and error fixes. Ashfire908@639d9b6
- Fixed potential issue where the wrong room join failure could be responded to. Ashfire908@c545be6
- Fixed mediated invites. Ashfire908@36ddb6c
