### PR TITLE
removed the restriction on the @ in the user field of the JID

### DIFF
--- a/sleekxmpp/jid.py
+++ b/sleekxmpp/jid.py
@@ -28,13 +28,13 @@ from sleekxmpp.thirdparty import OrderedDict
 ILLEGAL_CHARS = '\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r' + \
                 '\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19' + \
                 '\x1a\x1b\x1c\x1d\x1e\x1f' + \
-                ' !"#$%&\'()*+,./:;<=>?@[\\]^_`{|}~\x7f'
+                ' !"#$%&\'()*+,./:;<=>?[\\]^_`{|}~\x7f'
 
 #: The basic regex pattern that a JID must match in order to determine
 #: the local, domain, and resource parts. This regex does NOT do any
 #: validation, which requires application of nodeprep, resourceprep, etc.
 JID_PATTERN = re.compile(
-    "^(?:([^\"&'/:<>@]{1,1023})@)?([^/@]{1,1023})(?:/(.{1,1023}))?$"
+    "^(?:([^\"&'/:<>]{1,1023})@)?([^/@]{1,1023})(?:/(.{1,1023}))?$"
 )
 
 #: The set of escape sequences for the characters not allowed by nodeprep.
@@ -107,7 +107,7 @@ nodeprep = stringprep_profiles.create(
         stringprep.in_table_c7,
         stringprep.in_table_c8,
         stringprep.in_table_c9,
-        lambda c: c in ' \'"&/:<>@'],
+        lambda c: c in ' \'"&/:<>'],
     unassigned=[stringprep.in_table_a1])
 
 # pylint: disable=c0103


### PR DESCRIPTION
Facebook's XMPP server is non-standard, but if you want to use PLAIN auth with their servers and log in with your FB email address your JID becomes user@email.com@chat.facebook.com where the JID user is user@email.com and the domain is chat.facebook.com. Removing this restriction allows you to use SleekXMPP with FB in this manner for auth. Needed it for a project, and thought others might run into this issue as well. This restriction catches auth errors on the client before going to the server, but it limits this API's ability to interface with services that use this type of auth. My recommendation is leave the error checking for this particular case to the server and enable compatibility with more services.
