### PR TITLE
Don't use the kerberos.GSSError.message attribute

### DIFF
--- a/sleekxmpp/features/feature_mechanisms/mechanisms.py
+++ b/sleekxmpp/features/feature_mechanisms/mechanisms.py
@@ -215,6 +215,8 @@ class FeatureMechanisms(BasePlugin):
             self.attempted_mechs.add(self.mech.name)
             self.xmpp.disconnect()
         else:
+            if resp.get_value() == '':
+                resp.del_value()
             resp.send(now=True)
 
     def _handle_success(self, stanza):

--- a/sleekxmpp/util/sasl/mechanisms.py
+++ b/sleekxmpp/util/sasl/mechanisms.py
@@ -532,6 +532,9 @@ else:
                     result = kerberos.authGSSClientStep(self.gss, b64_challenge)
                     if result != kerberos.AUTH_GSS_CONTINUE:
                         self.step = 1
+                elif not challenge:
+                    kerberos.authGSSClientClean(self.gss)
+                    return b''
                 elif self.step == 1:
                     username = self.credentials['username']
 

--- a/sleekxmpp/util/sasl/mechanisms.py
+++ b/sleekxmpp/util/sasl/mechanisms.py
@@ -541,7 +541,7 @@ else:
 
                 resp = kerberos.authGSSClientResponse(self.gss)
             except kerberos.GSSError as e:
-                raise SASLCancelled('Kerberos error: %s' % e.message)
+                raise SASLCancelled('Kerberos error: %s' % e)
             if not resp:
                 return b''
             else:


### PR DESCRIPTION
Replaced the reference to kerberos.GSSError.message in any raised exception, because:
    DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
and its natural repr is probably the most desirable output.
