### PR TITLE
Fixes log.debug message in _connect_proxy

### DIFF
--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -611,7 +611,7 @@ class XMLStream(object):
         headers = '\r\n'.join(headers) + '\r\n\r\n'
 
         try:
-            log.debug("Connecting to proxy: %s:%s", address)
+            log.debug("Connecting to proxy: %s:%s", *address)
             self.socket.connect(address)
             self.send_raw(headers, now=True)
             resp = ''


### PR DESCRIPTION
This fixes a traceback if log level is set to DEBUG and connecting to a proxy
