### PR TITLE
Fixed a unicode error in xep_0065 on Python 3

### DIFF
--- a/sleekxmpp/plugins/xep_0065/proxy.py
+++ b/sleekxmpp/plugins/xep_0065/proxy.py
@@ -206,7 +206,7 @@ class XEP_0065(base_plugin):
             # Though this should not be neccessary remove the closed session anyway
             with self._sessions_lock:
                 if sid in self._sessions:
-                    log.warn(('SOCKS5 session with sid = "%s" was not ' + 
+                    log.warn(('SOCKS5 session with sid = "%s" was not ' +
                               'removed from _sessions by sock.close()') % sid)
                     del self._sessions[sid]
 
@@ -240,9 +240,9 @@ class XEP_0065(base_plugin):
         # The hostname MUST be SHA1(SID + Requester JID + Target JID)
         # where the output is hexadecimal-encoded (not binary).
         digest = sha1()
-        digest.update(sid)
-        digest.update(str(requester))
-        digest.update(str(target))
+        digest.update(sid.encode('utf-8'))
+        digest.update(str(requester).encode('utf-8'))
+        digest.update(str(target).encode('utf-8'))
 
         dest = digest.hexdigest()
 

--- a/sleekxmpp/thirdparty/socks.py
+++ b/sleekxmpp/thirdparty/socks.py
@@ -28,6 +28,9 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMANGE.
 This module provides a standard socket-like interface for Python
 for tunneling connections through SOCKS proxies.
 
+"""
+
+"""
 
 Minor modifications made by Christopher Gilbert (http://motomastyle.com/)
 for use in PyLoris (http://pyloris.sourceforge.net/)
@@ -35,10 +38,13 @@ for use in PyLoris (http://pyloris.sourceforge.net/)
 Minor modifications made by Mario Vilas (http://breakingcode.wordpress.com/)
 mainly to merge bug fixes found in Sourceforge
 
+Minor modifications made by Eugene Dementiev (http://www.dementiev.eu/)
+
 """
 
 import socket
 import struct
+import sys
 
 PROXY_TYPE_SOCKS4 = 1
 PROXY_TYPE_SOCKS5 = 2
@@ -208,7 +214,7 @@ class socksocket(socket.socket):
             if self.__proxy[3]:
                 # Resolve remotely
                 ipaddr = None
-                req = req + chr(0x03).encode() + chr(len(destaddr)).encode() + destaddr
+                req = req + chr(0x03).encode() + chr(len(destaddr)).encode() + destaddr.encode()
             else:
                 # Resolve locally
                 ipaddr = socket.inet_aton(socket.gethostbyname(destaddr))
@@ -323,7 +329,10 @@ class socksocket(socket.socket):
         # We read the response until we get the string "\r\n\r\n"
         resp = self.recv(1)
         while resp.find("\r\n\r\n".encode()) == -1:
-            resp = resp + self.recv(1)
+            recv = self.recv(1)
+            if not recv:
+                raise GeneralProxyError((1, _generalerrors[1]))
+            resp = resp + recv
         # We just need the first line to check if the connection
         # was successful
         statusline = resp.splitlines()[0].split(" ".encode(), 2)


### PR DESCRIPTION
Related to issue #296. I haven't tested on Python 2 to verify this doesn't break anything. Even with this patch, I still cannot transfer files via the proxy because of another error in the thirdparty/socks module.
