### PR TITLE
Added wait param to XEP_0009 RemoteSession.close

### DIFF
--- a/sleekxmpp/plugins/xep_0009/remote.py
+++ b/sleekxmpp/plugins/xep_0009/remote.py
@@ -569,11 +569,11 @@ class RemoteSession(object):
             self._register_callback(pid, callback)
             iq.send()
 
-    def close(self):
+    def close(self, wait=False):
         '''
         Closes this session.
         '''
-        self._client.disconnect(False)
+        self._client.disconnect(wait=wait)
         self._session_close_callback()
 
     def _on_jabber_rpc_method_call(self, iq):


### PR DESCRIPTION
This method currently makes a non-explicit decision to pass wait=False to the underlying disconnect call. This can often be undesired behavior, and sort of subverts the implication of calling it "disconnect". I would prefer to pass async=True, which would more explicitly alter the typical understanding of the method name, but for backwards compatibility have preserved the current behavior as the default.
