### PR TITLE
Fix saslprep on the username

### DIFF
--- a/sleekxmpp/util/sasl/mechanisms.py
+++ b/sleekxmpp/util/sasl/mechanisms.py
@@ -223,17 +223,16 @@ class SCRAM(Mech):
         return self.hash(text).digest()
 
     def saslname(self, value):
-        escaped = b''
-        for char in bytes(value):
-            if char == b',':
-                escaped += b'=2C'
-            elif char == b'=':
-                escaped += b'=3D'
+        value = value.decode("utf-8")
+        escaped = []
+        for char in value:
+            if char == ',':
+                escaped += '=2C'
+            elif char == '=':
+                escaped += '=3D'
             else:
-                if isinstance(char, int):
-                    char = chr(char)
-                escaped += bytes(char)
-        return escaped
+                escaped += char
+        return "".join(escaped).encode("utf-8")
 
     def parse(self, challenge):
         items = {}


### PR DESCRIPTION
Two issues fixed here:
- ints are not comparable with bytes, so char was never == to b',', which
  renders the whole function pointless
- The bytes were converted back to “characters” by using chr(), which
  doesn’t make sense if the username contains characters that fit on more
  than one bytes. This would trigger an “invalid username” error from the
  server when using a non-ascii JID.
