### PR TITLE
Extend AtomEntry capabilities

### DIFF
--- a/sleekxmpp/stanza/atom.py
+++ b/sleekxmpp/stanza/atom.py
@@ -6,8 +6,7 @@
     See the file LICENSE for copying permission.
 """
 
-from sleekxmpp.xmlstream import ElementBase
-
+from sleekxmpp.xmlstream import register_stanza_plugin, ElementBase
 
 class AtomEntry(ElementBase):
 
@@ -22,5 +21,23 @@ class AtomEntry(ElementBase):
     namespace = 'http://www.w3.org/2005/Atom'
     name = 'entry'
     plugin_attrib = 'entry'
-    interfaces = set(('title', 'summary'))
-    sub_interfaces = set(('title', 'summary'))
+    interfaces = set(('title', 'summary', 'id', 'published', 'updated'))
+    sub_interfaces = set(('title', 'summary', 'id', 'published',
+                          'updated'))
+
+class AtomAuthor(ElementBase):
+
+    """
+    An Atom author.
+
+    Stanza Interface:
+        name -- The printable author name
+        uri  -- The bare jid of the author
+    """
+
+    name = 'author'
+    plugin_attrib = 'author'
+    interfaces = set(('name', 'uri'))
+    sub_interfaces = set(('name', 'uri'))
+
+register_stanza_plugin(AtomEntry, AtomAuthor)


### PR DESCRIPTION
This adds support for `id`, `published`, `updated` and `author`.

The goal is to eventually support the use cases laid out in [XEP-0277](http://xmpp.org/extensions/xep-0277.html). I don't think there's a point in adding a full plugin just for that.
