### PR TITLE
On initial connect use delay if connection failed

### DIFF
--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -460,9 +460,11 @@ class XMLStream(object):
     def _connect(self, reattempt=True):
         self.scheduler.remove('Session timeout check')
 
-        if self.reconnect_delay is None or not reattempt:
+        if self.reconnect_delay is None:
             delay = 1.0
-        else:
+            self.reconnect_delay = delay
+                                                 
+        if reattempt:
             delay = min(self.reconnect_delay * 2, self.reconnect_max_delay)
             delay = random.normalvariate(delay, delay * 0.1)
             log.debug('Waiting %s seconds before connecting.', delay)


### PR DESCRIPTION
If server is unavailable from the beginning, then SleekXMPP will try to reconnect too often which in turns floods the log:
`[2014-11-23 16:09:00] sleekxmpp.xmlstream.xmlstream |ERROR| Could not connect to 192.168.1.3:5222. Socket Error #111: Connection refused
[2014-11-23 16:09:00] sleekxmpp.xmlstream.xmlstream |ERROR| Could not connect to 192.168.1.3:5222. Socket Error #111: Connection refused`
But if connection lost during normal work that's ok, reconnections happen with delay.
I added this delay on first connect too
