### PR TITLE
In queues added option to remove first element on addind new if queue is full

### DIFF
--- a/sleekxmpp/util/__init__.py
+++ b/sleekxmpp/util/__init__.py
@@ -32,12 +32,17 @@ def _gevent_threads_enabled():
 
 if _gevent_threads_enabled():
     import gevent.queue as queue
-    Queue = queue.JoinableQueue
+    _queue = queue.JoinableQueue
 else:
     try:
         import queue
     except ImportError:
         import Queue as queue
-    Queue = queue.Queue
+    _queue = queue.Queue
+class Queue(_queue):
+    def put(self, item, block=True, timeout=None):
+        if _queue.full(self):
+            _queue.get(self)
+        return _queue.put(self, item, block, timeout)
 
 QueueEmpty = queue.Empty

--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -291,7 +291,7 @@ class XMLStream(object):
         self.event_queue = Queue()
 
         #: A queue of string data to be sent over the stream.
-        self.send_queue = Queue()
+        self.send_queue = Queue(maxsize=256)
         self.send_queue_lock = threading.Lock()
         self.send_lock = threading.RLock()
 


### PR DESCRIPTION
When server is not available for a few hours (in my case) sleekxmpp dies trying to reconnect. It dies faster if you are trying to send messages when disconnected.
I've found a solution (highly probable a bad one) - don't allow send queue to overflow. Without maxsize parameter the queue is "unlimited", but physical memory is not (especially on my embedded device). Without maxsize parameter put() will block until a free slot available which is also not a good idea, I think.
So, I created a queue which will drop first element if you try to put an element when queue is full. It works, but I feel there is a better solution.
