### PR TITLE
Fix the element name for retrieving certs in XEP-0257

### DIFF
--- a/sleekxmpp/plugins/xep_0257/stanza.py
+++ b/sleekxmpp/plugins/xep_0257/stanza.py
@@ -10,7 +10,7 @@ from sleekxmpp.xmlstream import ElementBase, ET, register_stanza_plugin
 
 
 class Certs(ElementBase):
-    name = 'query'
+    name = 'items'
     namespace = 'urn:xmpp:saslcert:1'
     plugin_attrib = 'sasl_certs'
     interfaces = set()


### PR DESCRIPTION
http://xmpp.org/extensions/xep-0257.html#example-3 says the subelement must be an `<items/>` and not a `<query/>`.
