### PR TITLE
ssl-version not passed to wrap_socket, fixed

### DIFF
--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -523,7 +523,8 @@ class XMLStream(object):
                 'keyfile': self.keyfile,
                 'ca_certs': self.ca_certs,
                 'cert_reqs': cert_policy,
-                'do_handshake_on_connect': False
+                'do_handshake_on_connect': False,
+                "ssl_version": self.ssl_version
             })
 
             if sys.version_info >= (2, 7):
@@ -847,7 +848,8 @@ class XMLStream(object):
             'keyfile': self.keyfile,
             'ca_certs': self.ca_certs,
             'cert_reqs': cert_policy,
-            'do_handshake_on_connect': False
+            'do_handshake_on_connect': False,
+            "ssl_version": self.ssl_version
         })
 
         if sys.version_info >= (2, 7):


### PR DESCRIPTION
I was trying to connect to an openfire xmpp server which I think does not support tlsv1, using sleekxmpp 1.3.11.
The old version of Sleekxmpp I had (1.1.11) worked fine. 

Looking at the code, it seems to me that self.ssl_version should be passed to wrap_socket, which is the case in version 1.1.11.  But it's somehow left out in current code base.
