### PR TITLE
Fixed bug #353 Python3 XEP-0084 error

### DIFF
--- a/examples/set_avatar.py
+++ b/examples/set_avatar.py
@@ -63,7 +63,7 @@ class AvatarSetter(sleekxmpp.ClientXMPP):
 
         avatar_file = None
         try:
-            avatar_file = open(os.path.expanduser(self.filepath))
+            avatar_file = open(os.path.expanduser(self.filepath), 'rb')
         except IOError:
             print('Could not find file: %s' % self.filepath)
             return self.disconnect()

--- a/sleekxmpp/plugins/xep_0084/stanza.py
+++ b/sleekxmpp/plugins/xep_0084/stanza.py
@@ -8,7 +8,7 @@
 
 from base64 import b64encode, b64decode
 
-from sleekxmpp.util import bytes
+from sleekxmpp.util import bytes as sbytes
 from sleekxmpp.xmlstream import ET, ElementBase, register_stanza_plugin
 
 
@@ -20,12 +20,15 @@ class Data(ElementBase):
 
     def get_value(self):
         if self.xml.text:
-            return b64decode(bytes(self.xml.text))
+            return b64decode(sbytes(self.xml.text))
         return ''
 
     def set_value(self, value):
         if value:
-            self.xml.text = b64encode(bytes(value))
+            self.xml.text = b64encode(sbytes(value))
+            # Python3 base64 encoded is bytes and needs to be decoded to string
+            if isinstance(self.xml.text, bytes):
+                self.xml.text = self.xml.text.decode()
         else:
             self.xml.text = ''
 


### PR DESCRIPTION
There were 2 issues related to Python3:
1. example file didnt have specified file type that was opened
2. by default Python3 base64 encode return bytes object and it needed to be string so it had to be decoded when setting xml.text 
