### PR TITLE
XEP_332: Prefixed request and response with "http"

### DIFF
--- a/sleekxmpp/plugins/xep_0332/http.py
+++ b/sleekxmpp/plugins/xep_0332/http.py
@@ -109,7 +109,7 @@ class XEP_0332(BasePlugin):
         iq['http-req']['resource'] = resource
         iq['http-req']['version'] = '1.1'        # TODO: set this implicitly
         if data is not None:
-            iq['http-req']['http-data'] = data
+            iq['http-req']['data'] = data
         return iq.send(
             timeout=kwargs.get('timeout', None),
             block=kwargs.get('block', True),
@@ -128,7 +128,7 @@ class XEP_0332(BasePlugin):
         iq['http-resp']['message'] = message
         iq['http-resp']['version'] = '1.1'       # TODO: set this implicitly
         if data is not None:
-            iq['http-resp']['http-data'] = data
+            iq['http-resp']['data'] = data
         return iq.send(
             timeout=kwargs.get('timeout', None),
             block=kwargs.get('block', True),

--- a/sleekxmpp/plugins/xep_0332/http.py
+++ b/sleekxmpp/plugins/xep_0332/http.py
@@ -17,7 +17,9 @@ from sleekxmpp.xmlstream.handler import Callback
 from sleekxmpp.xmlstream.matcher import StanzaPath
 
 from sleekxmpp.plugins.base import BasePlugin
-from sleekxmpp.plugins.xep_0332.stanza import Request, Response, Data
+from sleekxmpp.plugins.xep_0332.stanza import (
+    HTTPRequest, HTTPResponse, HTTPData
+)
 from sleekxmpp.plugins.xep_0131.stanza import Headers
 
 
@@ -50,18 +52,26 @@ class XEP_0332(BasePlugin):
     }
 
     def plugin_init(self):
-        self.xmpp.register_handler(Callback(
-            'HTTP Request', StanzaPath('iq/req'), self._handle_request
-        ))
-        self.xmpp.register_handler(Callback(
-            'HTTP Response', StanzaPath('iq/resp'), self._handle_response
-        ))
-        register_stanza_plugin(Iq, Request, iterable=True)
-        register_stanza_plugin(Iq, Response, iterable=True)
-        register_stanza_plugin(Request, Headers, iterable=True)
-        register_stanza_plugin(Request, Data, iterable=True)
-        register_stanza_plugin(Response, Headers, iterable=True)
-        register_stanza_plugin(Response, Data, iterable=True)
+        self.xmpp.register_handler(
+            Callback(
+                'HTTP Request',
+                StanzaPath('iq/http-req'),
+                self._handle_request
+            )
+        )
+        self.xmpp.register_handler(
+            Callback(
+                'HTTP Response',
+                StanzaPath('iq/http-resp'),
+                self._handle_response
+            )
+        )
+        register_stanza_plugin(Iq, HTTPRequest, iterable=True)
+        register_stanza_plugin(Iq, HTTPResponse, iterable=True)
+        register_stanza_plugin(HTTPRequest, Headers, iterable=True)
+        register_stanza_plugin(HTTPRequest, HTTPData, iterable=True)
+        register_stanza_plugin(HTTPResponse, Headers, iterable=True)
+        register_stanza_plugin(HTTPResponse, HTTPData, iterable=True)
         # TODO: Should we register any api's here? self.api.register()
 
     def plugin_end(self):
@@ -94,12 +104,12 @@ class XEP_0332(BasePlugin):
         iq['from'] = self.xmpp.boundjid
         iq['to'] = to
         iq['type'] = 'set'
-        iq['req']['headers'] = headers
-        iq['req']['method'] = method
-        iq['req']['resource'] = resource
-        iq['req']['version'] = '1.1'        # TODO: set this implicitly
+        iq['http-req']['headers'] = headers
+        iq['http-req']['method'] = method
+        iq['http-req']['resource'] = resource
+        iq['http-req']['version'] = '1.1'        # TODO: set this implicitly
         if data is not None:
-            iq['req']['data'] = data
+            iq['http-req']['http-data'] = data
         return iq.send(
             timeout=kwargs.get('timeout', None),
             block=kwargs.get('block', True),
@@ -113,12 +123,12 @@ class XEP_0332(BasePlugin):
         iq['from'] = self.xmpp.boundjid
         iq['to'] = to
         iq['type'] = 'result'
-        iq['resp']['headers'] = headers
-        iq['resp']['code'] = code
-        iq['resp']['message'] = message
-        iq['resp']['version'] = '1.1'       # TODO: set this implicitly
+        iq['http-resp']['headers'] = headers
+        iq['http-resp']['code'] = code
+        iq['http-resp']['message'] = message
+        iq['http-resp']['version'] = '1.1'       # TODO: set this implicitly
         if data is not None:
-            iq['resp']['data'] = data
+            iq['http-resp']['http-data'] = data
         return iq.send(
             timeout=kwargs.get('timeout', None),
             block=kwargs.get('block', True),

--- a/sleekxmpp/plugins/xep_0332/http.py
+++ b/sleekxmpp/plugins/xep_0332/http.py
@@ -136,12 +136,12 @@ class XEP_0332(BasePlugin):
             timeout_callback=kwargs.get('timeout_callback', None)
         )
 
-    def send_error(self, to=None, ecode=500, etype='wait',
+    def send_error(self, to=None, ecode='500', etype='wait',
                    econd='internal-server-error', **kwargs):
         iq = self.xmpp.Iq()
-        iq['type'] = 'error'
         iq['from'] = self.xmpp.boundjid
         iq['to'] = to
+        iq['type'] = 'error'
         iq['error']['code'] = ecode
         iq['error']['type'] = etype
         iq['error']['condition'] = econd

--- a/sleekxmpp/plugins/xep_0332/stanza/__init__.py
+++ b/sleekxmpp/plugins/xep_0332/stanza/__init__.py
@@ -8,6 +8,6 @@
     See the file LICENSE for copying permission.
 """
 
-from sleekxmpp.plugins.xep_0332.stanza.request import Request
-from sleekxmpp.plugins.xep_0332.stanza.response import Response
-from sleekxmpp.plugins.xep_0332.stanza.data import Data
+from sleekxmpp.plugins.xep_0332.stanza.request import HTTPRequest
+from sleekxmpp.plugins.xep_0332.stanza.response import HTTPResponse
+from sleekxmpp.plugins.xep_0332.stanza.data import HTTPData

--- a/sleekxmpp/plugins/xep_0332/stanza/data.py
+++ b/sleekxmpp/plugins/xep_0332/stanza/data.py
@@ -18,7 +18,7 @@ class HTTPData(ElementBase):
     name = 'data'
     namespace = 'urn:xmpp:http'
     interfaces = set(['data'])
-    plugin_attrib = 'http-data'
+    plugin_attrib = 'data'
     is_extension = True
 
     def get_data(self, encoding='text'):

--- a/sleekxmpp/plugins/xep_0332/stanza/data.py
+++ b/sleekxmpp/plugins/xep_0332/stanza/data.py
@@ -11,14 +11,14 @@
 from sleekxmpp.xmlstream import ElementBase
 
 
-class Data(ElementBase):
+class HTTPData(ElementBase):
     """
     The data element.
     """
     name = 'data'
     namespace = 'urn:xmpp:http'
     interfaces = set(['data'])
-    plugin_attrib = 'data'
+    plugin_attrib = 'http-data'
     is_extension = True
 
     def get_data(self, encoding='text'):

--- a/sleekxmpp/plugins/xep_0332/stanza/request.py
+++ b/sleekxmpp/plugins/xep_0332/stanza/request.py
@@ -11,16 +11,19 @@
 from sleekxmpp.xmlstream import ElementBase
 
 
-class Request(ElementBase):
+class HTTPRequest(ElementBase):
 
     """
     All HTTP communication is done using the `Request`/`Response` paradigm.
-    Each HTTP Request is made sending an `iq` stanza containing a `req` element
-    to the server. Each `iq` stanza sent is of type `set`.
+    Each HTTP Request is made sending an `iq` stanza containing a `req`
+    element to the server. Each `iq` stanza sent is of type `set`.
 
     Examples:
     <iq type='set' from='a@b.com/browser' to='x@y.com' id='1'>
-        <req xmlns='urn:xmpp:http' method='GET' resource='/api/users' version='1.1'>
+        <req xmlns='urn:xmpp:http'
+             method='GET'
+             resource='/api/users'
+             version='1.1'>
             <headers xmlns='http://jabber.org/protocol/shim'>
                 <header name='Host'>b.com</header>
             </headers>
@@ -28,7 +31,10 @@ class Request(ElementBase):
     </iq>
 
     <iq type='set' from='a@b.com/browser' to='x@y.com' id='2'>
-        <req xmlns='urn:xmpp:http' method='PUT' resource='/api/users' version='1.1'>
+        <req xmlns='urn:xmpp:http'
+             method='PUT'
+             resource='/api/users'
+             version='1.1'>
             <headers xmlns='http://jabber.org/protocol/shim'>
                 <header name='Host'>b.com</header>
                 <header name='Content-Type'>text/html</header>
@@ -44,7 +50,7 @@ class Request(ElementBase):
     name = 'request'
     namespace = 'urn:xmpp:http'
     interfaces = set(['method', 'resource', 'version'])
-    plugin_attrib = 'req'
+    plugin_attrib = 'http-req'
 
     def get_method(self):
         return self._get_attr('method', None)

--- a/sleekxmpp/plugins/xep_0332/stanza/response.py
+++ b/sleekxmpp/plugins/xep_0332/stanza/response.py
@@ -11,7 +11,7 @@
 from sleekxmpp.xmlstream import ElementBase
 
 
-class Response(ElementBase):
+class HTTPResponse(ElementBase):
 
     """
     When the HTTP Server responds, it does so by sending an `iq` stanza
@@ -21,8 +21,13 @@ class Response(ElementBase):
     in which the original requests were made.
 
     Examples:
-    <iq type='result' from='httpserver@clayster.com' to='httpclient@clayster.com/browser' id='2'>
-        <resp xmlns='urn:xmpp:http' version='1.1' statusCode='200' statusMessage='OK'>
+    <iq type='result'
+        from='httpserver@clayster.com'
+        to='httpclient@clayster.com/browser' id='2'>
+        <resp xmlns='urn:xmpp:http'
+              version='1.1'
+              statusCode='200'
+              statusMessage='OK'>
             <headers xmlns='http://jabber.org/protocol/shim'>
                 <header name='Date'>Fri, 03 May 2013 16:39:54GMT-4</header>
                 <header name='Server'>Clayster</header>
@@ -42,7 +47,7 @@ class Response(ElementBase):
     name = 'response'
     namespace = 'urn:xmpp:http'
     interfaces = set(['code', 'message', 'version'])
-    plugin_attrib = 'resp'
+    plugin_attrib = 'http-resp'
 
     def get_code(self):
         code = self._get_attr('statusCode', None)


### PR DESCRIPTION
Hi @bear - 

I just noticed that the following commits were not part of my earlier pull request. 

https://github.com/sangeeths/SleekXMPP/commit/61a7cecb319c5628973906250ed973f21883cfd4
https://github.com/sangeeths/SleekXMPP/commit/d60a652259c74aaea4a250c542ce5ceaeb81f177 
https://github.com/sangeeths/SleekXMPP/commit/1345b7c1d0b3c121471034521e9028cd43569cb7 

The unit test failures was due to plugin_attrib name collision between XEP_332 and XEP_323. I have updated the data structures used in XEP_332 so that each and every iq across plugins will be uniquely identified. 
