### PR TITLE
XEP-0096 : added file hash to payload

### DIFF
--- a/sleekxmpp/plugins/xep_0096/file_transfer.py
+++ b/sleekxmpp/plugins/xep_0096/file_transfer.py
@@ -39,7 +39,7 @@ class XEP_0096(BasePlugin):
         self.xmpp['xep_0095'].unregister_profile(File.namespace, self)
 
     def request_file_transfer(self, jid, sid=None, name=None, size=None,
-                                    desc=None, hash=None, date=None,
+                                    desc=None, file_hash=None, date=None,
                                     allow_ranged=False, mime_type=None,
                                     **iqargs):
         data = File()
@@ -47,6 +47,10 @@ class XEP_0096(BasePlugin):
         data['size'] = size
         data['date'] = date
         data['desc'] = desc
+
+        if file_hash is not None:
+            data['hash'] = file_hash
+
         if allow_ranged:
             data.enable('range')
 


### PR DESCRIPTION
#### Added file hash param to payload so that it can be integrated in resulting _iq_

While exchanging files it is necessary to check the integrity of the file and the hash was not being sent in the resulting **<file>** tag in _iq_ as a param.

Variable name was changed because it leads to confusion with builtin python **hash** function

I don't know changing _variable name_ will lead to any breaking changes for others, but this differentiation looks pretty solid to me. And since it was previously not present I doubt anyone was using it before.
