### PR TITLE
add hash metadata for file transfer

### DIFF
--- a/sleekxmpp/plugins/xep_0096/file_transfer.py
+++ b/sleekxmpp/plugins/xep_0096/file_transfer.py
@@ -47,6 +47,7 @@ class XEP_0096(BasePlugin):
         data['size'] = size
         data['date'] = date
         data['desc'] = desc
+        data['hash'] = hash
         if allow_ranged:
             data.enable('range')
 


### PR DESCRIPTION
Add hash to file metadata  in payload as defined in the xep standard : http://xmpp.org/extensions/xep-0096.html#reqs
