### PR TITLE
Initialize certfile, keyfile and ca_certs in XMLStream. Added **kwargs to ClientXMPP, BaseXMPP and XMLStream.

### DIFF
--- a/sleekxmpp/basexmpp.py
+++ b/sleekxmpp/basexmpp.py
@@ -55,8 +55,8 @@ class BaseXMPP(XMLStream):
                        is used during initialization.
     """
 
-    def __init__(self, jid='', default_ns='jabber:client'):
-        XMLStream.__init__(self)
+    def __init__(self, jid='', default_ns='jabber:client', **kwargs):
+        XMLStream.__init__(self, **kwargs)
 
         self.default_ns = default_ns
         self.stream_ns = 'http://etherx.jabber.org/streams'

--- a/sleekxmpp/clientxmpp.py
+++ b/sleekxmpp/clientxmpp.py
@@ -59,14 +59,15 @@ class ClientXMPP(BaseXMPP):
     :param escape_quotes: **Deprecated.**
     """
 
-    def __init__(self, jid, password, plugin_config=None, plugin_whitelist=None, escape_quotes=True, sasl_mech=None,
-                 lang='en'):
+    def __init__(self, jid, password, plugin_config=None,
+                 plugin_whitelist=None, escape_quotes=True, sasl_mech=None,
+                 lang='en', **kwargs):
         if not plugin_whitelist:
             plugin_whitelist = []
         if not plugin_config:
             plugin_config = {}
 
-        BaseXMPP.__init__(self, jid, 'jabber:client')
+        BaseXMPP.__init__(self, jid, 'jabber:client', **kwargs)
 
         self.escape_quotes = escape_quotes
         self.plugin_config = plugin_config

--- a/sleekxmpp/xmlstream/cert.py
+++ b/sleekxmpp/xmlstream/cert.py
@@ -181,4 +181,4 @@ def verify(expected, raw_cert):
             return True
 
     raise CertificateError(
-            'Could not match certficate against hostname: %s' % expected)
+            'Could not match certificate against hostname: %s' % expected)

--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -114,7 +114,8 @@ class XMLStream(object):
     :param int port: The port to use for the connection. Defaults to 0.
     """
 
-    def __init__(self, socket=None, host='', port=0):
+    def __init__(self, socket=None, host='', port=0, certfile=None,
+                 keyfile=None, ca_certs=None, **kwargs):
         #: Most XMPP servers support TLSv1, but OpenFire in particular
         #: does not work well with it. For OpenFire, set
         #: :attr:`ssl_version` to use ``SSLv23``::
@@ -136,16 +137,16 @@ class XMLStream(object):
         #:
         #:     On Mac OS X, certificates in the system keyring will
         #:     be consulted, even if they are not in the provided file.
-        self.ca_certs = None
+        self.ca_certs = ca_certs
 
         #: Path to a file containing a client certificate to use for
         #: authenticating via SASL EXTERNAL. If set, there must also
         #: be a corresponding `:attr:keyfile` value.
-        self.certfile = None
+        self.certfile = certfile
 
         #: Path to a file containing the private key for the selected
         #: client certificate to use for authenticating via SASL EXTERNAL.
-        self.keyfile = None
+        self.keyfile = keyfile
 
         self._der_cert = None
 


### PR DESCRIPTION
Currently we would need to hardcode the paths to certfile, keyfile and ca_certs in XMLStream. With this patch, we can pass them when we create ClientXMPP.
