### PR TITLE
Fix UnboundlocalError in disco_browser.py example

### DIFF
--- a/examples/disco_browser.py
+++ b/examples/disco_browser.py
@@ -94,7 +94,7 @@ class Disco(sleekxmpp.ClientXMPP):
                 info = self['xep_0030'].get_info(jid=self.target_jid,
                                                  node=self.target_node,
                                                  block=True)
-            elif self.get in self.items_types:
+            if self.get in self.items_types:
                 # The same applies from above. Listen for the
                 # disco_items event or pass a callback function
                 # if you need to process a non-blocking request.


### PR DESCRIPTION
If `self.get` is in `self.info_types` and `self.items_types`, only `self['xep_0030'].get_info` is executed and not `self['xep_0030'].get_items`. So the condition in line 129 is successful but `items` is not assigned.
