### PR TITLE
XEP_0050: Form not iterable in command stanza

### DIFF
--- a/sleekxmpp/plugins/xep_0050/adhoc.py
+++ b/sleekxmpp/plugins/xep_0050/adhoc.py
@@ -425,12 +425,25 @@ class XEP_0050(BasePlugin):
 
             del self.sessions[sessionid]
 
+            payload = session['payload']
+            if payload is None:
+                payload = []
+            if not isinstance(payload, list):
+                payload = [payload]
+
+            for item in payload:
+                register_stanza_plugin(Command, item.__class__, iterable=True)
+
             iq.reply()
             iq['command']['node'] = node
             iq['command']['sessionid'] = sessionid
             iq['command']['actions'] = []
             iq['command']['status'] = 'completed'
             iq['command']['notes'] = session['notes']
+
+            for item in payload:
+                iq['command'].append(item)
+
             iq.send()
         else:
             raise XMPPError('item-not-found')

--- a/sleekxmpp/plugins/xep_0050/adhoc.py
+++ b/sleekxmpp/plugins/xep_0050/adhoc.py
@@ -101,7 +101,7 @@ class XEP_0050(BasePlugin):
                          self._handle_command))
 
         register_stanza_plugin(Iq, Command)
-        register_stanza_plugin(Command, Form)
+        register_stanza_plugin(Command, Form, iterable=True)
 
         self.xmpp.add_event_handler('command_execute',
                                     self._handle_command_start,

--- a/tests/test_stream_xep_0050.py
+++ b/tests/test_stream_xep_0050.py
@@ -120,6 +120,7 @@ class TestAdHocCommands(SleekTest):
 
             def handle_form(form, session):
                 results.append(form['values']['foo'])
+                session['payload'] = None
 
             form = self.xmpp['xep_0004'].makeForm('form')
             form.addField(var='foo', ftype='text-single', label='Foo')
@@ -192,6 +193,7 @@ class TestAdHocCommands(SleekTest):
 
             def handle_step2(form, session):
                 results.append(form['values']['bar'])
+                session['payload'] = None
 
             def handle_step1(form, session):
                 results.append(form['values']['foo'])
@@ -427,6 +429,7 @@ class TestAdHocCommands(SleekTest):
             def handle_form(forms, session):
                 for form in forms:
                     results.append(form['values']['FORM_TYPE'])
+                session['payload'] = None
 
             form1 = self.xmpp['xep_0004'].makeForm('form')
             form1.addField(var='FORM_TYPE', ftype='hidden', value='form_1')


### PR DESCRIPTION
Cannot pass in a form into the initial command and have it show up in the payload of the session.  Line 344 makes this possible when following the standard workflow.
