### PR TITLE
iot: only add the 'done' field when all devices are done

### DIFF
--- a/sleekxmpp/plugins/xep_0323/sensordata.py
+++ b/sleekxmpp/plugins/xep_0323/sensordata.py
@@ -482,10 +482,10 @@ class XEP_0323(BasePlugin):
             if result == "done":
                 self.sessions[session]["commTimers"][nodeId].cancel()
                 self.sessions[session]["nodeDone"][nodeId] = True
-                msg['fields']['done'] = 'true'
                 if (self._all_nodes_done(session)):
                     # The session is complete, delete it
                     del self.sessions[session]
+                    msg['fields']['done'] = 'true'
             else:
                 # Restart comm timer
                 self.sessions[session]["commTimers"][nodeId].reset()


### PR DESCRIPTION
Currently, all messages for devices in an IoT server are sent with the 'done' attribute set to 'true' when requested with 'all' set to 'true'. This causes a KeyError on the client side because this triggers the removal of the session and results in the attempted deletion of a no-longer-existent key. I have move the line that sets the 'done' attribute so that it is set when all nodes are done.
