### PR TITLE
Retaining 'id' in the response and error stanzas

### DIFF
--- a/sleekxmpp/plugins/xep_0332/http.py
+++ b/sleekxmpp/plugins/xep_0332/http.py
@@ -127,6 +127,8 @@ class XEP_0332(BasePlugin):
         iq['http-resp']['code'] = code
         iq['http-resp']['message'] = message
         iq['http-resp']['version'] = '1.1'       # TODO: set this implicitly
+        if 'id' in kwargs:
+            iq['id'] = kwargs["id"]
         if data is not None:
             iq['http-resp']['data'] = data
         return iq.send(
@@ -145,6 +147,8 @@ class XEP_0332(BasePlugin):
         iq['error']['code'] = ecode
         iq['error']['type'] = etype
         iq['error']['condition'] = econd
+        if 'id' in kwargs:
+            iq['id'] = kwargs["id"]
         return iq.send(
             timeout=kwargs.get('timeout', None),
             block=kwargs.get('block', True),


### PR DESCRIPTION
Hi @bear - This fix will let us use the same id in the `response` and `error` stanzas so that we could do the following in order to send a response.

```
self['xep_0332'].send_response(
    to="alice@foobar/home", code=200, message="OK", id=iq["id"]
)
```
