### PR TITLE
Add get users by affiliation.

### DIFF
--- a/sleekxmpp/plugins/xep_0045.py
+++ b/sleekxmpp/plugins/xep_0045.py
@@ -397,6 +397,16 @@ class XEP_0045(BasePlugin):
             return None
         return self.rooms[room].keys()
 
+    def getUsersByAffiliation(cls, room, affiliation='member', ifrom=None):
+        if affiliation not in ('outcast', 'member', 'admin', 'owner', 'none'):
+            raise TypeError
+        query = ET.Element('{http://jabber.org/protocol/muc#admin}query')
+        item = ET.Element('{http://jabber.org/protocol/muc#admin}item', {'affiliation': affiliation})
+        query.append(item)
+        iq = cls.xmpp.Iq(sto=room, sfrom=ifrom, stype='get')
+        iq.append(query)
+        return iq.send()
+
 
 xep_0045 = XEP_0045
 register_plugin(XEP_0045)


### PR DESCRIPTION
Added a functionality to request list of room occupants by their affiliation, e.g.:
http://xmpp.org/extensions/xep-0045.html
Example 196. Owner Requests Admin List

```
<iq from='bard@shakespeare.lit/desktop'
    id='admin3'
    to='coven@chat.shakespeare.lit'
    type='get'>
  <query xmlns='http://jabber.org/protocol/muc#admin'>
    <item affiliation='admin'/>
  </query>
</iq>
```
