### PR TITLE
Do not overwrite telephone numbers

### DIFF
--- a/sleekxmpp/plugins/xep_0054/stanza.py
+++ b/sleekxmpp/plugins/xep_0054/stanza.py
@@ -128,7 +128,8 @@ class Telephone(ElementBase):
 
     def setup(self, xml=None):
         super(Telephone, self).setup(xml=xml)
-        self._set_sub_text('NUMBER', '', keep=True)
+        ## this blanks out numbers received from server
+        ##self._set_sub_text('NUMBER', '', keep=True)
 
     def set_number(self, value):
         self._set_sub_text('NUMBER', value, keep=True)


### PR DESCRIPTION
The setup() constructor sets NUMBER to blank, but if SleekXMPP is the client this overwrites NUMBERs sent from server. 
