### PR TITLE
adding 'id' to self['xep_0332'].send_request()

### DIFF
--- a/sleekxmpp/plugins/xep_0332/http.py
+++ b/sleekxmpp/plugins/xep_0332/http.py
@@ -108,6 +108,8 @@ class XEP_0332(BasePlugin):
         iq['http-req']['method'] = method
         iq['http-req']['resource'] = resource
         iq['http-req']['version'] = '1.1'        # TODO: set this implicitly
+        if 'id' in kwargs:
+            iq['id'] = kwargs["id"]
         if data is not None:
             iq['http-req']['data'] = data
         return iq.send(


### PR DESCRIPTION
@bear 

This is w.r.t. XEP-0332. I have added `id` to `send_request()`. I should have covered this during my last commit itself. Apologies for missing it earlier. 

Thanks.

http://xmpp.org/extensions/xep-0332.html
