### PR TITLE
Fix #383: TypeError if arg[0] is socket object

### DIFF
--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -1677,7 +1677,10 @@ class XMLStream(object):
 
                 etype, handler = event[0:2]
                 args = event[2:]
-                orig = copy.copy(args[0])
+                try:
+                    orig = copy.copy(args[0])
+                except TypeError:
+                    orig = args[0]
 
                 if etype == 'stanza':
                     try:


### PR DESCRIPTION
The copy operation raises a TypeError because the socket is not serializable. Copying the
object should only prevent the handler from changing it so "orig.excpetion(e)" can still be
executed. However, the socket object does not have a "exception" method so it is save to
only hold a reference in orig.

This can be removed once everything is read-only as described in the todo in line 1175
