### PR TITLE
Python3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,14 @@ packages     = [ 'sleekxmpp',
                  'sleekxmpp/thirdparty',
                  ]
 
+python_version = sys.version_info
+python_requirements = ['pyasn1', 'pyasn1_modules']
+
+if python_version(0) == 3:
+    python_requirements.append('dnspython3')
+else:
+    python_requirements.append('dnspython')
+
 setup(
     name             = "sleekxmpp",
     version          = VERSION,
@@ -153,7 +161,7 @@ setup(
     license      = 'MIT',
     platforms    = [ 'any' ],
     packages     = packages,
-    requires     = [ 'dnspython', 'pyasn1', 'pyasn1_modules' ],
+    requires     = python_requirements,
     classifiers  = CLASSIFIERS,
     cmdclass     = {'test': TestCommand}
 )

--- a/setup.py
+++ b/setup.py
@@ -142,10 +142,9 @@ packages     = [ 'sleekxmpp',
                  'sleekxmpp/thirdparty',
                  ]
 
-python_version = sys.version_info
 python_requirements = ['pyasn1', 'pyasn1_modules']
 
-if python_version(0) == 3:
+if sys.version_info.major == 3:
     python_requirements.append('dnspython3')
 else:
     python_requirements.append('dnspython')


### PR DESCRIPTION
Use dnspython3 instead of dnspython if installing with python3+.
