### PR TITLE
Use `ssl.get_protocol_name()` to find out which TLS version is in use

### DIFF
--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -464,7 +464,7 @@ class XMLStream(object):
         if self.reconnect_delay is None:
             delay = 1.0
             self.reconnect_delay = delay
-                                                 
+
         if reattempt:
             delay = min(self.reconnect_delay * 2, self.reconnect_max_delay)
             delay = random.normalvariate(delay, delay * 0.1)
@@ -839,8 +839,10 @@ class XMLStream(object):
         to be restarted.
         """
         log.info("Negotiating TLS")
-        ssl_versions = {3: 'TLS 1.0', 1: 'SSL 3', 2: 'SSL 2/3'}
-        log.info("Using SSL version: %s", ssl_versions[self.ssl_version])
+        log.info(
+            "Using SSL version: %s",
+            ssl.get_protocol_name(self.ssl_version).replace('PROTOCOL_', '', 1)
+        )
         if self.ca_certs is None:
             cert_policy = ssl.CERT_NONE
         else:


### PR DESCRIPTION
I need to use TLSv1.2 for a project I am working on, it appears that it is possible to set the `self.ssl_version` attribute to `ssl.PROTOCOL_TLSv1_2` but then the debug log throws a KeyError exception. This can be fixed one of 2 ways:
- Add entries in the hardcoded dict of `ssl_versions` (`4` and `5` for `TLSv1.1` and `TLSv1.2` respectively).
- Use the `ssl.get_protocol_name()` method to let the Python SSL library do it for us.

I chose the latter because when new versions get added to the library they would most probably be added to the `ssl.get_protocol_name()` method, which means next time I won't have to do a pull request. :)

Note: The format of the log output will be slightly different because the string format is different from the hardcoded dictionary. If someone is using this log entry in a script, it may break. However I think it's fair to assume that we can safely change this.
