### PR TITLE
Update tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
+sudo: false
 language: python
-python: 3.5
-env:
-  - TOXENV=py27
-  - TOXENV=py34
-  - TOXENV=py35
 install: pip install tox
 script: tox
+
+matrix:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-install:
-  - "pip install ."
-script: testall.py
+python: 3.5
+env:
+  - TOXENV=py27
+  - TOXENV=py34
+  - TOXENV=py35
+install: pip install tox
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34
+envlist = py27,py34,py35
 [testenv]
 deps = nose
 commands = nosetests --where=tests --exclude=live -i sleektest.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py{27,34,35,36}
+
 [testenv]
 deps = nose
 commands = nosetests --where=tests --exclude=live -i sleektest.py


### PR DESCRIPTION
This pull-request:
- drops python 2.6 tests
- adds python 3.5 tests
- uses tox from travis

partial solution to #419

[Build passes](https://travis-ci.org/medecau/SleekXMPP/builds/150164591)
