### PR TITLE
Rework SSL/TLS Implementation

### DIFF
--- a/sleekxmpp/xmlstream/xmlstream.py
+++ b/sleekxmpp/xmlstream/xmlstream.py
@@ -116,13 +116,21 @@ class XMLStream(object):
 
     def __init__(self, socket=None, host='', port=0, certfile=None,
                  keyfile=None, ca_certs=None, **kwargs):
-        #: Most XMPP servers support TLSv1, but OpenFire in particular
-        #: does not work well with it. For OpenFire, set
-        #: :attr:`ssl_version` to use ``SSLv23``::
+        #: Default ssl_version is ``PROTOCOL_SSLv23``, but despite the name,
+        #: ``PROTOCOL_SSLv23`` means to enable all possible SSL/TLS versions.
+        #: In addition, SSLv2 & SSLv3 is insecure, we have explictly disabled
+        #: them during the connections, which is considered as the best practice.
+        #: Thus, ironically, ``PROTOCOL_SSLv23`` enables everything except SSLv2/3.
         #:
-        #:     import ssl
-        #:     xmpp.ssl_version = ssl.PROTOCOL_SSLv23
-        self.ssl_version = ssl.PROTOCOL_TLSv1
+        #: .. note::
+        #:
+        #:     Most XMPP servers support TLSv1 or newer, however, if you really have to
+        #:     connect to systems with insecure SSLv3, you may set :attr:`ssl_version`
+        #:     as ``ssl.PROTOCOL_SSLv3``. Other values are ignored by current implementation.
+        #:
+        #:         import ssl
+        #:         xmpp.ssl_version = ssl.PROTOCOL_SSLv3
+        self.ssl_version = ssl.PROTOCOL_SSLv23
 
         #: The list of accepted ciphers, in OpenSSL Format.
         #: It might be useful to override it for improved security
@@ -408,10 +416,30 @@ class XMLStream(object):
         return "%s%X" % (self._id_prefix, self._id)
 
     def _create_secure_socket(self):
+        _CIPHERS_SSL = (
+            'ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+HIGH:'
+            'DH+HIGH:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+HIGH:RSA+3DES:!aNULL:'
+            '!eNULL:!MD5'
+        )
+
+        # 3DES is vulnerable to Sweet32 attack, thus it is not used in TLS connections,
+        # however, for SSL connections, it is the only usable cipher for some programs.
+        _CIPHERS_TLS = (
+            'ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:DH+CHACHA20:ECDH+AES256:DH+AES256:'
+            'ECDH+AES128:DH+AES:ECDH+HIGH:DH+HIGH:RSA+AESGCM:RSA+AES:RSA+HIGH:'
+            '!aNULL:!eNULL:!MD5:!3DES'
+        )
+
         log.info(
-            "Using SSL version: %s",
+            "Using SSL/TLS version: %s",
             ssl.get_protocol_name(self.ssl_version).replace('PROTOCOL_', '', 1)
         )
+        if self.ssl_version == ssl.PROTOCOL_SSLv23:
+            log.info(
+                "Note: SSLv23 doesn't mean SSLv2 and SSLv3, but means all "
+                "supported versions, actually TLSv1.0+, since SSLv2 and "
+                "SSLv3 is disabled."
+            )
 
         if self.ca_certs is None:
             cert_policy = ssl.CERT_NONE
@@ -424,13 +452,76 @@ class XMLStream(object):
             'ca_certs': self.ca_certs,
             'cert_reqs': cert_policy,
             'do_handshake_on_connect': False,
-            "ssl_version": self.ssl_version
         })
 
-        if sys.version_info >= (2, 7):
-            ssl_args['ciphers'] = self.ciphers
+        if sys.version_info > (3,):
+            if sys.version_info >= (3, 4):
+                # Good, create_default_context() is supported, which consists
+                # recommended security settings by default.
+                ctx = ssl.create_default_context()
+                if self.ssl_version == ssl.PROTOCOL_SSLv3:
+                    # But if the user specifies insecure SSLv3, do a favor.
+                    ctx.options &= ~ssl.OP_NO_SSLv3  # UNSET NO_SSLv3, or set SSLv3
+                    ctx.set_ciphers(_CIPHERS_SSL)  # _CIPHERS_SSL is weaker
 
-        return = ssl.wrap_socket(self.socket, **ssl_args)
+                # XXX: certificate is not verified in most circumstances.
+                # FIXME: need to provide a new option that verifies against system CAs.
+                if cert_policy == ssl.CERT_NONE:
+                    ctx.check_hostname = False
+                    ctx.verify_mode = ssl.CERT_NONE
+                elif cert_policy == ssl.CERT_REQUIRED:
+                    ctx.load_verify_locations(cafile=self.ca_certs)
+            else:
+                # Oops, create_default_context() is not supported.
+                if self.ssl_version == ssl.PROTOCOL_SSLv3:
+                    # First, if the user specifies insecure SSLv3, do a favor.
+                    ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv3)
+                    ctx.set_ciphers(_CIPHERS_SSL)
+                else:
+                    # Or, set the version to TLSv1 (later is not supported),
+                    # and set a list of good ciphers.
+                    ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+                    ctx.set_ciphers(_CIPHERS_TLS)
+                # And in both case, CRIME attack needs to be prevented.
+                if sys.version_info >= (3, 3):
+                    ctx.options &= ssl.OP_NO_COMPRESSION
+
+                # Verify the certificate.
+                if cert_policy == ssl.CERT_NONE:
+                    ctx.check_hostname = False
+                    ctx.verify_mode = ssl.CERT_NONE
+                elif cert_policy == ssl.CERT_REQUIRED:
+                    ctx.check_hostname = True
+                    ctx.verify_mode = ssl.CERT_REQUIRED
+                    ctx.load_verify_locations(cafile=self.ca_certs)
+        elif sys.version_info >= (2, 7, 9):
+            # Good, create_default_context() is supported, do the same as Python 3.4.
+            ctx = ssl.create_default_context()
+            if self.ssl_version == ssl.PROTOCOL_SSLv3:
+                # If the user specifies insecure SSLv3, do a favor.
+                ctx.options &= ~ssl.OP_NO_SSLv3
+                ctx.set_ciphers(_CIPHERS_SSL)
+            if cert_policy == ssl.CERT_NONE:
+                # XXX: certificate is not verified!
+                ctx.check_hostname = False
+                ctx.verify_mode = ssl.CERT_NONE
+            elif cert_policy == ssl.CERT_REQUIRED:
+                ctx.load_verify_locations(cafile=self.ca_certs)
+        else:
+            if self.ssl_version == ssl.PROTOCOL_SSLv3:
+                ssl_args['ssl_version'] = ssl.PROTOCOL_SSLv3
+            else:
+                ssl_args['ssl_version'] = ssl.PROTOCOL_TLSv1
+            ctx = None
+
+        if ctx:
+            if self.ciphers:
+                ctx.set_ciphers(self.ciphers)
+            return ctx.wrap_socket(self.socket, do_handshake_on_connect=False)
+        else:
+            if self.ciphers and sys.version_info >= (2, 7):
+                ssl_args['ciphers'] = self.ciphers
+            return ssl.wrap_socket(self.socket, **ssl_args)
 
     def connect(self, host='', port=0, use_ssl=False,
                 use_tls=True, reattempt=True):


### PR DESCRIPTION
Due to historical issues, the original implementation of SSL/TLS
in xmlstream.py hardcoded self.ssl_version = ssl.PROTOCOL_TLSv1,
which is the only supported TLS in Python at the time, and causes
a interoperability problem , that prevents connecting to a server with
TLSv1.1/1.2 but doesn't support TLSv1.

Simply changing ssl_version to ssl.PROTOCOL_SSLv23, that allows all
versions of SSL/TLS, including TLSv1.2 in newer Python, could fix the
problem. However, it introduces more security hazards, since SSLv2
and SSLv3 is not disabled, the connection is vulnerable to various
attacks.

In addition, the implementation did not use the best practice when
establishing connections, for example, any ciphers provided by OpenSSL
is used, including RC4, which is vulnerable; SSL compression may be
used, which is vulnerable to CRIME attack.

Therefore, a rework of the entire SSL/TLS implementation is needed,
to fix the interoperability problem, and provide better connections.

This commit introduces the following changes:
- Default ssl_version is set as `PROTOCOL_SSLv23`, but SSLv2
  and SSLv3 is explicitly disabled, allowing us to use any latest TLS
  versions. As a fallback, if users really have to work with an insecure
  server, `PROTOCOL_SSLv3` may be set.
- The most complicated part, is the new behavior on creating SSL
  sockets. Even if new features is provided in stdlib, we have to make it
  it secure on different versions of Python(s).
- First, if Python 3.4/2.7.9 or newer is found, we are going to use
  ssl.create_default_context, a new function, that provides (partially)
  secure settings. This is the best choice, allowing security updates
  to be delivered with Python.
- Second, if Python 3 is used, but not as new as 3.4, we use
  ssl.SSLContext(), and initialize it with ssl.PROTOCOL_TLSv1, because
  this is the only supported TLS in previous Python. We also set a list
  of good ciphers, _CIPHERS_TLS, which is taken from latest Python. Then
  we disable SSL Compression to prevent CRIME attacks.
- Third, if Python 2.7 is running, but not as new as 2.7.9, we have
  to call ssl.wrap_socket() directly, and use ssl.PROTOCOL_TLSv1.
- As the fallback mentioned before, a user may have to deal with a
  server with outdated and insecure SSLv3, we need to add other conditions
  to make sure a SSLv3 connection can be established. To achieve this,
  if ssl.PROTOCOL_SSLv3 is used, for Python 3.4/2.7.9, we deselect
  ssl.OP_NO_SSLv3, or select SSLv3; for older Python 3 or 2.7, we
  initialize with ssl.PROTOCOL_SSLv3 instead.
- This is not enough, our ciphers list should include ciphers that SSLv3
  servers can understand. So, a list of ciphers, _CIPHERS_SSL, which is
  also taken from Python stdlib, but with a 3DES fallback.
- Finally, still due to historical problem, early Python can not verify
  server-side certificates, unless a file contains CAs is specified. But in
  newer Python, a system-wide CAs can be used for verification without specifying
  CAs manually. But in xmltream.py, the presence of self.ca_certs,
  directly disables/enables the verification. In the new code, this
  original behavior is respected and implemented.

After all, this commit strengthen the SSL/TLS security, but does not
complete solves it. In other words, in most circumstances, server-side
certificates are not verified at all. A man in the middle just needs to
send a self-signed certificate to hijack your connection, making all the
changes mentioned before meaningless. We have to figure out a way to add
a new option to fix this, but also compatible with current library
users.

Signed-off-by: Tom Li biergaizi@member.fsf.org
