### PR TITLE
Add missing parameters to configure() for XEP-0223,0224

### DIFF
--- a/sleekxmpp/plugins/xep_0222.py
+++ b/sleekxmpp/plugins/xep_0222.py
@@ -28,7 +28,8 @@ class XEP_0222(BasePlugin):
     profile = {'pubsub#persist_items': True,
                'pubsub#send_last_published_item': 'never'}
 
-    def configure(self, node):
+    def configure(self, node, ifrom=None, block=None, callback=None,
+                  timeout=None):
         """
         Update a node's configuration to match the public storage profile.
         """

--- a/sleekxmpp/plugins/xep_0223.py
+++ b/sleekxmpp/plugins/xep_0223.py
@@ -28,7 +28,8 @@ class XEP_0223(BasePlugin):
     profile = {'pubsub#persist_items': True,
                'pubsub#send_last_published_item': 'never'}
 
-    def configure(self, node):
+    def configure(self, node, ifrom=None, block=None, callback=None,
+                  timeout=None):
         """
         Update a node's configuration to match the public storage profile.
         """


### PR DESCRIPTION
Otherwise the timeout,ifrom,block and callback parameters would be used but not defined, leading to a crash.
