### PR TITLE
Add XMPPError to XEP-0050

### DIFF
--- a/sleekxmpp/plugins/xep_0050/adhoc.py
+++ b/sleekxmpp/plugins/xep_0050/adhoc.py
@@ -10,7 +10,7 @@ import logging
 import time
 
 from sleekxmpp import Iq
-from sleekxmpp.exceptions import IqError
+from sleekxmpp.exceptions import IqError, XMPPError
 from sleekxmpp.xmlstream.handler import Callback
 from sleekxmpp.xmlstream.matcher import StanzaPath
 from sleekxmpp.xmlstream import register_stanza_plugin, JID


### PR DESCRIPTION
XEP-0050 mostly raises XMPPError when something happens, but XMPPError is not defined in adhoc.py, leading to a new traceback inside the traceback handler.
