### PR TITLE
Fix a typo in XEP-0221

### DIFF
--- a/sleekxmpp/plugins/xep_0221/stanza.py
+++ b/sleekxmpp/plugins/xep_0221/stanza.py
@@ -36,7 +36,7 @@ class URI(ElementBase):
         self.xml.text = value
 
     def del_value(self):
-        sel.xml.text = ''
+        self.xml.text = ''
 
 
 register_stanza_plugin(Media, URI, iterable=True)


### PR DESCRIPTION
Using del 'value' on a URI element would crash.
