### PR TITLE
conform to RFC5280 when extracting certificates validity dates

### DIFF
--- a/sleekxmpp/xmlstream/cert.py
+++ b/sleekxmpp/xmlstream/cert.py
@@ -108,10 +108,20 @@ def extract_dates(raw_cert):
 
     not_before = validity.getComponentByName('notBefore')
     not_before = str(not_before.getComponent())
+    if len(not_before) == 13:  # UTCTime
+        if int(not_before[:2]) >= 50:
+            not_before = '19' + not_before
+        else:
+            not_before = '20' + not_before
     not_before = datetime.strptime(not_before, '%Y%m%d%H%M%SZ')
 
     not_after = validity.getComponentByName('notAfter')
     not_after = str(not_after.getComponent())
+    if len(not_after) == 13:  # UTCTime
+        if int(not_after[:2]) >= 50:
+            not_after = '19' + not_after
+        else:
+            not_after = '20' + not_after
     not_after = datetime.strptime(not_after, '%Y%m%d%H%M%SZ')
 
     return not_before, not_after


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc5280#section-4.1.2.5.1 :

	4.1.2.5.1.  UTCTime

	   The universal time type, UTCTime, is a standard ASN.1 type intended
	   for representation of dates and time.  UTCTime specifies the year
	   through the two low-order digits and time is specified to the
	   precision of one minute or one second.  UTCTime includes either Z
	   (for Zulu, or Greenwich Mean Time) or a time differential.

	   For the purposes of this profile, UTCTime values MUST be expressed in
	   Greenwich Mean Time (Zulu) and MUST include seconds (i.e., times are
	   YYMMDDHHMMSSZ), even where the number of seconds is zero.  Conforming
	   systems MUST interpret the year field (YY) as follows:

	      Where YY is greater than or equal to 50, the year SHALL be
	      interpreted as 19YY; and

	      Where YY is less than 50, the year SHALL be interpreted as 20YY.