### PR TITLE
Fix extracting dates from certificates using UTCTime

### DIFF
--- a/sleekxmpp/xmlstream/cert.py
+++ b/sleekxmpp/xmlstream/cert.py
@@ -1,6 +1,5 @@
 import logging
-import pytz
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, tzinfo
 
 # Make a call to strptime before starting threads to
 # prevent thread safety issues.
@@ -31,6 +30,17 @@ log = logging.getLogger(__name__)
 
 class CertificateError(Exception):
     pass
+
+
+class UTC(tzinfo):
+    def utcoffset(self, dt):
+        return timedelta(0)
+    def tzname(self, dt):
+        return "UTC"
+    def dst(self, dt):
+        return timedelta(0)
+
+utc = UTC()
 
 
 def decode_str(data):
@@ -109,11 +119,11 @@ def extract_dates(raw_cert):
 
     not_before = validity.getComponentByName('notBefore')
     not_before = not_before.getComponent().asDateTime
-    not_before = not_before.astimezone(pytz.UTC).replace(tzinfo = None)
+    not_before = not_before.astimezone(utc).replace(tzinfo = None)
 
     not_after = validity.getComponentByName('notAfter')
     not_after = not_after.getComponent().asDateTime
-    not_after = not_after.astimezone(pytz.UTC).replace(tzinfo = None)
+    not_after = not_after.astimezone(utc).replace(tzinfo = None)
 
     return not_before, not_after
 

--- a/sleekxmpp/xmlstream/cert.py
+++ b/sleekxmpp/xmlstream/cert.py
@@ -1,4 +1,5 @@
 import logging
+import pytz
 from datetime import datetime, timedelta
 
 # Make a call to strptime before starting threads to
@@ -107,12 +108,12 @@ def extract_dates(raw_cert):
     validity = tbs.getComponentByName('validity')
 
     not_before = validity.getComponentByName('notBefore')
-    not_before = str(not_before.getComponent())
-    not_before = datetime.strptime(not_before, '%Y%m%d%H%M%SZ')
+    not_before = not_before.getComponent().asDateTime
+    not_before = not_before.astimezone(pytz.UTC).replace(tzinfo = None)
 
     not_after = validity.getComponentByName('notAfter')
-    not_after = str(not_after.getComponent())
-    not_after = datetime.strptime(not_after, '%Y%m%d%H%M%SZ')
+    not_after = not_after.getComponent().asDateTime
+    not_after = not_after.astimezone(pytz.UTC).replace(tzinfo = None)
 
     return not_before, not_after
 


### PR DESCRIPTION
When connecting to ejabberd with .pam certificates, I was getting error that certificate is expired.

I have debugged the issue and it turned out, that notBefore and notAfter components of certificate are encoded as UTCTime in my certificate. That data format have only 2 digits of year, versus 4 digits in GeneralizedTime. That difference was causing datetime.strptime to wrongly interpret year.

My change is avoiding conversion to/from string in favour of using built in pyasn1 methods for conversion to datetime. That solution should work independent on time format used in cerificate.