### PR TITLE
Make rpc call parameters optional

### DIFF
--- a/sleekxmpp/plugins/xep_0009/rpc.py
+++ b/sleekxmpp/plugins/xep_0009/rpc.py
@@ -54,13 +54,14 @@ class XEP_0009(BasePlugin):
         self.xmpp['xep_0030'].add_feature('jabber:iq:rpc')
         self.xmpp['xep_0030'].add_identity('automation','rpc')
 
-    def make_iq_method_call(self, pto, pmethod, params):
+    def make_iq_method_call(self, pto, pmethod, params = None):
         iq = self.xmpp.makeIqSet()
         iq.attrib['to'] = pto
         iq.attrib['from'] = self.xmpp.boundjid.full
         iq.enable('rpc_query')
         iq['rpc_query']['method_call']['method_name'] = pmethod
-        iq['rpc_query']['method_call']['params'] = params
+        if params is not None:
+            iq['rpc_query']['method_call']['params'] = params
         return iq
 
     def make_iq_method_response(self, pid, pto, params):


### PR DESCRIPTION
According to RPC schema specification https://xmpp.org/extensions/xep-0009.html#schema,
the params element is optional. This change allows for making a call without providing
parameters.