### PR TITLE
XEP-0313: fix pagination support

### DIFF
--- a/sleekxmpp/plugins/xep_0313/stanza.py
+++ b/sleekxmpp/plugins/xep_0313/stanza.py
@@ -142,8 +142,8 @@ class MAM_Fin(ElementBase):
     name = 'fin'
     namespace = 'urn:xmpp:mam:2'
     plugin_attrib = 'mam_answer'
-    interfaces = set(['queryid', 'complete', 'results'])
-
+    interfaces = set(['queryid', 'results'])
+    bool_interfaces = set(['complete'])
 
     # The results interface is meant only as an easy
     # way to access the set of collected message responses


### PR DESCRIPTION
When the server sets attribute `complete="false"` to the `fin` tag
(like ejabberd does), it was being incorrectly interpreted as true.