### PR TITLE
Added comment for TLSv1.2 to be used with ejabberd

### DIFF
--- a/examples/send_client.py
+++ b/examples/send_client.py
@@ -124,6 +124,11 @@ if __name__ == '__main__':
     # If you are working with an OpenFire server, you may need
     # to adjust the SSL version used:
     # xmpp.ssl_version = ssl.PROTOCOL_SSLv3
+    
+    # For ejabberd you may need to adjust to TLSv1.2:
+    # xmpp.ssl_version = ssl.PROTOCOL_TLSv1_2
+    
+    # You will need to import import ssl for setting the SSL version.
 
     # If you want to verify the SSL certificates offered by a server:
     # xmpp.ca_certs = "path/to/ca/cert"


### PR DESCRIPTION
The example will only work with recent versions of ejabberd if TLSv1.2 is set.